### PR TITLE
O retorno de perfis não era nulo, era vazio e por isso que não estava vinculando corretamente

### DIFF
--- a/SME.CDEP.Aplicacao/Servicos/ServicoPerfilUsuario.cs
+++ b/SME.CDEP.Aplicacao/Servicos/ServicoPerfilUsuario.cs
@@ -20,7 +20,7 @@ namespace SME.CDEP.Aplicacao.Servicos
         {
             var retorno = await servicoAcessos.ObterPerfisUsuario(login);
             
-            if (retorno.PerfilUsuario.EhNulo())
+            if (retorno.PerfilUsuario.NaoPossuiElementos())
             {
                 await VincularPerfilExternoCoreSSO(login,new Guid(Constantes.PERFIL_EXTERNO_GUID));
                 retorno = await servicoAcessos.ObterPerfisUsuario(login);


### PR DESCRIPTION
[AB#116364](https://dev.azure.com/amcomgov/8217b3ef-9b0e-4b12-a2b0-a4fe910279ea/_workitems/edit/116364)