### PR TITLE
Importação de acervos documentais não estava tratando campos código e código novo como nulos quando não preenchidos

### DIFF
--- a/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
+++ b/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
@@ -73,8 +73,8 @@ namespace SME.CDEP.Aplicacao.Servicos
                     var acervoDocumental = new AcervoDocumentalCadastroDTO()
                     {
                         Titulo = acervoDocumentalLinha.Titulo.Conteudo,
-                        Codigo = acervoDocumentalLinha.Codigo.Conteudo,
-                        CodigoNovo = acervoDocumentalLinha.CodigoNovo.Conteudo,
+                        Codigo = acervoDocumentalLinha.Codigo.Conteudo.EstaPreenchido() ? acervoDocumentalLinha.Codigo.Conteudo : null,
+                        CodigoNovo = acervoDocumentalLinha.CodigoNovo.Conteudo.EstaPreenchido() ? acervoDocumentalLinha.CodigoNovo.Conteudo : null,
                         MaterialId = ObterMaterialDocumentalIdOuNuloPorValorDoCampo(acervoDocumentalLinha.Material.Conteudo),
                         IdiomaId = ObterIdiomaIdPorValorDoCampo(acervoDocumentalLinha.Idioma.Conteudo),
                         CreditosAutoresIds = ObterCreditoAutoresIdsPorValorDoCampo(acervoDocumentalLinha.Autor.Conteudo, TipoCreditoAutoria.Autoria, false),

--- a/SME.CDEP.Dominio/Constantes/MensagemNegocio.cs
+++ b/SME.CDEP.Dominio/Constantes/MensagemNegocio.cs
@@ -73,5 +73,5 @@ public class MensagemNegocio
     public const string ACERVO_EMPRESTADO = "Acervo emprestado pela solicitação '{0}'";
     public const string LIMITE_ACERVOS_IMPORTADOS_VIA_PLANILHA = "O limite de acervos importados por planilha não pode ser superior a '{0}' linhas";
     public const string IMPORTACAO_NAO_LOCALIZADA = "Importação não localizada";
-    public const string NAO_EH_PERMITIDO_AGENDAR_VISITA_NO_FINAL_DE_SEMANA = "Não é possível agendar visita no final de semana";
+    public const string NAO_EH_PERMITIDO_AGENDAR_VISITA_NO_FINAL_DE_SEMANA = "Não é permitido agendar visita no final de semana";
 }


### PR DESCRIPTION
[AB#120655](https://dev.azure.com/amcomgov/8217b3ef-9b0e-4b12-a2b0-a4fe910279ea/_workitems/edit/120655)