### PR TITLE
Ignorar propriedade da Editora no mapeamento do AcervoMap

### DIFF
--- a/SME.CDEP.Infra.Dados/Mapeamentos/AcervoMap.cs
+++ b/SME.CDEP.Infra.Dados/Mapeamentos/AcervoMap.cs
@@ -17,6 +17,7 @@ namespace SME.CDEP.Infra.Dados.Mapeamentos
             Map(c => c.Ano).ToColumn("ano");
             Map(c => c.AnoInicio).ToColumn("ano_inicio");
             Map(c => c.AnoFim).ToColumn("ano_fim");
+            Map(c => c.Editora).Ignore();
         }
     }
 }


### PR DESCRIPTION
A propriedade Editora agora é explicitamente ignorada na configuração de mapeamento do AcervoMap, impedindo que ela seja mapeada para o banco de dados.