### PR TITLE
Adicionar coluna capa_documento à tabela acervo

### DIFF
--- a/scripts/V52_ALTER_TABLE_ACERVO_CAPA_DOCUMENTO_OPCIONAL.sql
+++ b/scripts/V52_ALTER_TABLE_ACERVO_CAPA_DOCUMENTO_OPCIONAL.sql
@@ -1,0 +1,3 @@
+-- Adiciona a nova coluna para armazenar o nome do arquivo da imagem da capa
+ALTER TABLE public.acervo
+ADD COLUMN capa_documento VARCHAR(255) NULL;


### PR DESCRIPTION
Introduz uma nova coluna VARCHAR(255) anulável 'capa_documento' na tabela 'acervo' para armazenar o endereço do arquivo de imagem da capa no bucket.