### PR TITLE
Corrige erro de checksum na migração V52

### DIFF
--- a/scripts/V54__ALTER_TABLE_ACERVO_DOCUMENTAL_CAPA_DOCUMENTO_OPCIONAL.sql
+++ b/scripts/V54__ALTER_TABLE_ACERVO_DOCUMENTAL_CAPA_DOCUMENTO_OPCIONAL.sql
@@ -1,3 +1,3 @@
 -- Adiciona a nova coluna para armazenar o nome do arquivo da imagem da capa
-ALTER TABLE public.acervo
+ALTER TABLE public.acervo_documental
 ADD COLUMN capa_documento VARCHAR(255) NULL;

--- a/scripts/V54__ALTER_TABLE_ACERVO_DOCUMENTAL_CAPA_DOCUMENTO_OPCIONAL.sql
+++ b/scripts/V54__ALTER_TABLE_ACERVO_DOCUMENTAL_CAPA_DOCUMENTO_OPCIONAL.sql
@@ -1,3 +1,6 @@
+-- Remove a coluna capa_documento da tabela acervo se existir
+ALTER TABLE public.acervo DROP IF EXISTS capa_documento;
+
 -- Adiciona a nova coluna para armazenar o nome do arquivo da imagem da capa
 ALTER TABLE public.acervo_documental
 ADD COLUMN capa_documento VARCHAR(255) NULL;


### PR DESCRIPTION
Reverte o script V52 para o estado original e move a lógica para uma nova migração (V54) para resolver o erro de checksum mismatch do Flyway.