### PR TITLE
test: ampla cobertura de testes unitários

### DIFF
--- a/src/SME.CDEP.Aplicacao/DTOS/DiaMesDTO.cs
+++ b/src/SME.CDEP.Aplicacao/DTOS/DiaMesDTO.cs
@@ -2,7 +2,6 @@
 using SME.CDEP.Dominio.Constantes;
 using SME.CDEP.Dominio.Excecoes;
 using SME.CDEP.Dominio.Extensions;
-using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.Aplicacao.DTOS
 {

--- a/src/SME.CDEP.Aplicacao/Integracoes/ServicoAcessos.cs
+++ b/src/SME.CDEP.Aplicacao/Integracoes/ServicoAcessos.cs
@@ -1,13 +1,15 @@
 ﻿using Newtonsoft.Json;
-using System.Text;
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Aplicacao.Integracoes.Interfaces;
 using SME.CDEP.Dominio.Constantes;
 using SME.CDEP.Dominio.Excecoes;
 using SME.CDEP.Dominio.Extensions;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace SME.CDEP.Aplicacao.Integracoes
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoAcessos(HttpClient httpClient) : IServicoAcessos
     {
         private const int Sistema_Cdep = 1006;

--- a/src/SME.CDEP.Aplicacao/SME.CDEP.Aplicacao.csproj
+++ b/src/SME.CDEP.Aplicacao/SME.CDEP.Aplicacao.csproj
@@ -23,6 +23,7 @@
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
         <PackageReference Include="MimeKit" Version="4.14.0" />
         <PackageReference Include="Npgsql" Version="9.0.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
         <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
     </ItemGroup>

--- a/src/SME.CDEP.Aplicacao/Servicos/ServicoAplicacaoAuditavel.cs
+++ b/src/SME.CDEP.Aplicacao/Servicos/ServicoAplicacaoAuditavel.cs
@@ -8,7 +8,6 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Excecoes;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Dominio.Repositorios;
-using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {

--- a/src/SME.CDEP.Aplicacao/Servicos/ServicoConfirmacaoAtendimentoAcervo.cs
+++ b/src/SME.CDEP.Aplicacao/Servicos/ServicoConfirmacaoAtendimentoAcervo.cs
@@ -4,6 +4,7 @@ using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Constantes;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra;
 using SME.CDEP.Infra.Dominio.Enumerados;
 

--- a/src/SME.CDEP.Aplicacao/Servicos/ServicoDownloadArquivo.cs
+++ b/src/SME.CDEP.Aplicacao/Servicos/ServicoDownloadArquivo.cs
@@ -13,17 +13,8 @@ using SME.CDEP.Infra.Servicos.ServicoArmazenamento.Interface;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ServicoDownloadArquivo : IServicoDownloadArquivo
+    public class ServicoDownloadArquivo(IRepositorioArquivo repositorioArquivo, IServicoArmazenamento servicoArmazenamento) : IServicoDownloadArquivo
     {
-        private readonly IRepositorioArquivo repositorioArquivo;
-        private readonly IServicoArmazenamento servicoArmazenamento;
-        
-        public ServicoDownloadArquivo(IRepositorioArquivo repositorioArquivo,IServicoArmazenamento servicoArmazenamento)
-        {
-            this.repositorioArquivo = repositorioArquivo ?? throw new ArgumentNullException(nameof(repositorioArquivo));
-            this.servicoArmazenamento = servicoArmazenamento ?? throw new ArgumentNullException(nameof(servicoArmazenamento));
-        }
-       
         public async Task<(byte[], string, string)> Download(Guid codigoArquivo)
         {
             return await ObterArquivo(await repositorioArquivo.ObterPorCodigo(codigoArquivo));

--- a/src/SME.CDEP.Aplicacao/Servicos/ServicoGerarMiniatura.cs
+++ b/src/SME.CDEP.Aplicacao/Servicos/ServicoGerarMiniatura.cs
@@ -1,26 +1,17 @@
-﻿using SME.CDEP.Aplicacao.Extensions;
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.ServicoArmazenamento.Interface;
-using System.Drawing;
-using System.Net;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ServicoGerarMiniatura : IServicoGerarMiniatura
+    public class ServicoGerarMiniatura(IServicoArmazenamento servicoArmazenamento, IRepositorioArquivo repositorioArquivo,
+        IHttpClientFactory httpClientFactory) : IServicoGerarMiniatura
     {
-        private readonly IServicoArmazenamento servicoArmazenamento;
-        private readonly IRepositorioArquivo repositorioArquivo;
-
-        public ServicoGerarMiniatura(IServicoArmazenamento servicoArmazenamento, IRepositorioArquivo repositorioArquivo)
-        {
-            this.servicoArmazenamento = servicoArmazenamento ?? throw new ArgumentNullException(nameof(servicoArmazenamento));
-            this.repositorioArquivo = repositorioArquivo ?? throw new ArgumentNullException(nameof(repositorioArquivo));
-        }
-
         public async Task<long> GerarMiniatura(string tipoConteudo, string nomeArquivoFisico, string nomeArquivoMiniatura, TipoArquivo tipoArquivo)
         {
             var codigoArquivoMiniatura = Guid.NewGuid();
@@ -36,25 +27,25 @@ namespace SME.CDEP.Aplicacao.Servicos
         {
             var url = await servicoArmazenamento.Obter(nomeArquivoFisico, false);
 
-            using (WebClient webClient = new WebClient())
+            using var httpClient = httpClientFactory.CreateClient();
+            using var stream = await httpClient.GetStreamAsync(url);
+
+            using var imagem = await Image.LoadAsync(stream);
+
+            imagem.Mutate(x => x.Resize(new ResizeOptions
             {
-                using (Stream stream = webClient.OpenRead(url))
-                {
-                    using (Image imagem = Image.FromStream(stream))
-                    {
-                        var miniatura = imagem.GetThumbnailImage(320, 200, () => false, IntPtr.Zero);
+                Size = new Size(320, 200),
+                Mode = ResizeMode.Max
+            }));
 
-                        using (var msImagem = new MemoryStream())
-                        {
-                            miniatura.Save(msImagem, tipoConteudo.ObterFormato());
+            using var msImagem = new MemoryStream();
 
-                            msImagem.Seek(0, SeekOrigin.Begin);
+            var formatoOriginal = imagem.Metadata.DecodedImageFormat;
+            await imagem.SaveAsync(msImagem, formatoOriginal!);
 
-                            await servicoArmazenamento.Armazenar(codigoArquivoMiniaturaComExtensao, msImagem, tipoConteudo);
-                        }
-                    }
-                }
-            }
+            msImagem.Seek(0, SeekOrigin.Begin);
+
+            await servicoArmazenamento.Armazenar(codigoArquivoMiniaturaComExtensao, msImagem, tipoConteudo);
         }
 
         protected async Task<long> SalvarArquivoMiniaturaAsync(string nomeArquivoMiniatura, string tipoConteudo, TipoArquivo tipoArquivo, Guid codigoArquivoMiniatura)

--- a/src/SME.CDEP.Aplicacao/Servicos/ServicoNotificacaoEmail.cs
+++ b/src/SME.CDEP.Aplicacao/Servicos/ServicoNotificacaoEmail.cs
@@ -2,20 +2,13 @@
 using MimeKit;
 using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
-using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ServicoNotificacaoEmail : IServicoNotificacaoEmail
+    public class ServicoNotificacaoEmail(IRepositorioParametroSistema repositorioParametroSistema) : IServicoNotificacaoEmail
     {
-        private readonly IRepositorioParametroSistema repositorioParametroSistema;
-
-        public ServicoNotificacaoEmail(IRepositorioParametroSistema repositorioParametroSistema)
-        {
-            this.repositorioParametroSistema = repositorioParametroSistema ?? throw new ArgumentNullException(nameof(repositorioParametroSistema));
-        }
-
         public async Task<bool> Enviar(string nomeDestinatario, string emailDestinatario, string assunto, string mensagem)
         {
             var anoAtual = DateTimeExtension.HorarioBrasilia().Year;

--- a/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
@@ -11,41 +11,46 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ExecutarImportacaoArquivoAcervoDocumentalUseCase(
-        IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial, 
-        IServicoEditora servicoEditora, IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, 
-        IServicoAssunto servicoAssunto, IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, 
-        IServicoAcessoDocumento servicoAcessoDocumento, IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, 
-        IServicoFormato servicoFormato, IServicoAcervoDocumental servicoAcervoDocumental, IMapper mapper,
-        IRepositorioParametroSistema repositorioParametroSistema) : 
-        ServicoImportacaoArquivoBase(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, 
-            servicoIdioma, servicoAssunto, servicoCreditoAutor, servicoConservacao,servicoAcessoDocumento,servicoCromia,
-            servicoSuporte, servicoFormato, mapper,repositorioParametroSistema), 
-        IExecutarImportacaoArquivoAcervoDocumentalUseCase, IImportacaoArquivoAcervoDocumentalAuxiliar 
+    public class ExecutarImportacaoArquivoAcervoDocumentalUseCase : ServicoImportacaoArquivoBase, IExecutarImportacaoArquivoAcervoDocumentalUseCase, IImportacaoArquivoAcervoDocumentalAuxiliar
     {
+        private readonly IServicoAcervoDocumental servicoAcervoDocumental;
+        private readonly IMapper mapper;
+
+        public ExecutarImportacaoArquivoAcervoDocumentalUseCase(IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial,
+            IServicoEditora servicoEditora, IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto,
+            IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
+            IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, IServicoFormato servicoFormato, IServicoAcervoDocumental servicoAcervoDocumental, IMapper mapper,
+            IRepositorioParametroSistema repositorioParametroSistema)
+            : base(repositorioImportacaoArquivo, servicoMaterial, servicoEditora, servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor,
+                servicoConservacao, servicoAcessoDocumento, servicoCromia, servicoSuporte, servicoFormato, mapper, repositorioParametroSistema)
+        {
+            this.servicoAcervoDocumental = servicoAcervoDocumental ?? throw new ArgumentNullException(nameof(servicoAcervoDocumental));
+            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())
                 throw new NegocioException(MensagemNegocio.PARAMETROS_INVALIDOS);
 
             long importacaoArquivoId = 0;
-            
-            if (!long.TryParse(param.Mensagem.ToString(),out importacaoArquivoId))
+
+            if (!long.TryParse(param.Mensagem.ToString(), out importacaoArquivoId))
                 throw new NegocioException(MensagemNegocio.PARAMETROS_INVALIDOS);
-            
+
             var importacaoArquivo = await repositorioImportacaoArquivo.ObterPorId(importacaoArquivoId);
-            
+
             if (importacaoArquivo.EhNulo())
                 throw new NegocioException(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
-            
+
             await CarregarDominiosDocumentais();
 
             var acervosDocumentaisLinhas = JsonConvert.DeserializeObject<IEnumerable<AcervoDocumentalLinhaDTO>>(importacaoArquivo.Conteudo);
-            
+
             ValidarPreenchimentoValorFormatoQtdeCaracteres(acervosDocumentaisLinhas);
-            
+
             await PersistenciaAcervo(acervosDocumentaisLinhas);
-            await AtualizarImportacao(importacaoArquivoId, JsonConvert.SerializeObject(acervosDocumentaisLinhas), acervosDocumentaisLinhas.Any(a=> a.PossuiErros) ? ImportacaoStatus.Erros : ImportacaoStatus.Sucesso);
+            await AtualizarImportacao(importacaoArquivoId, JsonConvert.SerializeObject(acervosDocumentaisLinhas), acervosDocumentaisLinhas.Any(a => a.PossuiErros) ? ImportacaoStatus.Erros : ImportacaoStatus.Sucesso);
 
             return true;
         }
@@ -53,15 +58,15 @@ namespace SME.CDEP.Aplicacao.Servicos
         public async Task CarregarDominiosDocumentais()
         {
             await CarregarTodosOsDominios();
-            
+
             await ObterCreditosAutoresPorTipo(TipoCreditoAutoria.Autoria);
-                
+
             await ObterMateriaisPorTipo(TipoMaterial.DOCUMENTAL);
         }
 
         public async Task PersistenciaAcervo(IEnumerable<AcervoDocumentalLinhaDTO> acervosDocumentalLinhas)
         {
-            foreach (var acervoDocumentalLinha in acervosDocumentalLinhas.Where(w=> !w.PossuiErros))
+            foreach (var acervoDocumentalLinha in acervosDocumentalLinhas.Where(w => !w.PossuiErros))
             {
                 try
                 {
@@ -95,13 +100,13 @@ namespace SME.CDEP.Aplicacao.Servicos
                     acervoDocumentalLinha.DefinirLinhaComoErro(ex.Message);
                 }
             }
-        } 
+        }
 
         public void ValidarPreenchimentoValorFormatoQtdeCaracteres(IEnumerable<AcervoDocumentalLinhaDTO> linhas)
         {
-            var autores = CreditosAutores.Where(w => w.Tipo == (int)TipoCreditoAutoria.Autoria).Select(s=> mapper.Map<IdNomeDTO>(s));
-            var materiaisDocumentais = Materiais.Where(w => w.Tipo == (int)TipoMaterial.DOCUMENTAL).Select(s=> mapper.Map<IdNomeDTO>(s));
-            
+            var autores = CreditosAutores.Where(w => w.Tipo == (int)TipoCreditoAutoria.Autoria).Select(s => mapper.Map<IdNomeDTO>(s));
+            var materiaisDocumentais = Materiais.Where(w => w.Tipo == (int)TipoMaterial.DOCUMENTAL).Select(s => mapper.Map<IdNomeDTO>(s));
+
             foreach (var linha in linhas)
             {
                 try
@@ -110,40 +115,40 @@ namespace SME.CDEP.Aplicacao.Servicos
                     ValidarPreenchimentoLimiteCaracteres(linha.Codigo, Constantes.CODIGO_ANTIGO);
                     ValidarPreenchimentoLimiteCaracteres(linha.CodigoNovo, Constantes.CODIGO_NOVO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Material,Constantes.MATERIAL);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Material, Constantes.MATERIAL);
                     ValidarConteudoCampoComDominio(linha.Material, materiaisDocumentais, Constantes.MATERIAL);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Idioma,Constantes.IDIOMA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Idioma, Constantes.IDIOMA);
                     ValidarConteudoCampoComDominio(linha.Idioma, Idiomas, Constantes.IDIOMA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Autor,Constantes.AUTOR);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Autor, Constantes.AUTOR);
                     ValidarConteudoCampoListaComDominio(linha.Autor, autores, Constantes.AUTOR);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Ano,Constantes.ANO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.NumeroPaginas,Constantes.NUMERO_PAGINAS);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Ano, Constantes.ANO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.NumeroPaginas, Constantes.NUMERO_PAGINAS);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Volume,Constantes.VOLUME);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Descricao,Constantes.DESCRICAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Volume, Constantes.VOLUME);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Descricao, Constantes.DESCRICAO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.TipoAnexo,Constantes.TIPO_ANEXO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Largura,Constantes.LARGURA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.TipoAnexo, Constantes.TIPO_ANEXO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Largura, Constantes.LARGURA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Altura,Constantes.ALTURA);
-                    ValidarPreenchimentoLimiteCaracteres(linha.TamanhoArquivo,Constantes.TAMANHO_ARQUIVO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Altura, Constantes.ALTURA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.TamanhoArquivo, Constantes.TAMANHO_ARQUIVO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.AcessoDocumento,Constantes.ACESSO_DOCUMENTO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.AcessoDocumento, Constantes.ACESSO_DOCUMENTO);
                     ValidarConteudoCampoListaComDominio(linha.AcessoDocumento, AcessoDocumentos, Constantes.ACESSO_DOCUMENTO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Localizacao,Constantes.LOCALIZACAO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.CopiaDigital,Constantes.COPIA_DIGITAL);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Localizacao, Constantes.LOCALIZACAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.CopiaDigital, Constantes.COPIA_DIGITAL);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.EstadoConservacao,Constantes.ESTADO_CONSERVACAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.EstadoConservacao, Constantes.ESTADO_CONSERVACAO);
                     ValidarConteudoCampoComDominio(linha.EstadoConservacao, Conservacoes, Constantes.ESTADO_CONSERVACAO);
-                    
+
                     if (linha.Codigo.Conteudo.NaoEstaPreenchido() && linha.CodigoNovo.Conteudo.NaoEstaPreenchido())
                     {
-                        DefinirMensagemErro(linha.Codigo, string.Format(Constantes.CAMPO_X_NAO_PREENCHIDO,Constantes.CODIGO_ANTIGO));
-                        DefinirMensagemErro(linha.CodigoNovo, string.Format(Constantes.CAMPO_X_NAO_PREENCHIDO,Constantes.CODIGO_NOVO));
+                        DefinirMensagemErro(linha.Codigo, string.Format(Constantes.CAMPO_X_NAO_PREENCHIDO, Constantes.CODIGO_ANTIGO));
+                        DefinirMensagemErro(linha.CodigoNovo, string.Format(Constantes.CAMPO_X_NAO_PREENCHIDO, Constantes.CODIGO_NOVO));
                     }
                     linha.PossuiErros = PossuiErro(linha);
                 }
@@ -156,23 +161,23 @@ namespace SME.CDEP.Aplicacao.Servicos
 
         private bool PossuiErro(AcervoDocumentalLinhaDTO linha)
         {
-            return linha.Titulo.PossuiErro 
-                   || linha.Codigo.PossuiErro 
-                   || linha.CodigoNovo.PossuiErro 
+            return linha.Titulo.PossuiErro
+                   || linha.Codigo.PossuiErro
+                   || linha.CodigoNovo.PossuiErro
                    || linha.Material.PossuiErro
                    || linha.Idioma.PossuiErro
-                   || linha.Autor.PossuiErro 
-                   || linha.Ano.PossuiErro 
+                   || linha.Autor.PossuiErro
+                   || linha.Ano.PossuiErro
                    || linha.NumeroPaginas.PossuiErro
                    || linha.Volume.PossuiErro
                    || linha.Descricao.PossuiErro
                    || linha.TipoAnexo.PossuiErro
-                   || linha.Largura.PossuiErro 
+                   || linha.Largura.PossuiErro
                    || linha.Altura.PossuiErro
-                   || linha.TamanhoArquivo.PossuiErro 
-                   || linha.AcessoDocumento.PossuiErro 
-                   || linha.Localizacao.PossuiErro 
-                   || linha.CopiaDigital.PossuiErro 
+                   || linha.TamanhoArquivo.PossuiErro
+                   || linha.AcessoDocumento.PossuiErro
+                   || linha.Localizacao.PossuiErro
+                   || linha.CopiaDigital.PossuiErro
                    || linha.EstadoConservacao.PossuiErro;
         }
     }

--- a/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCase.cs
@@ -11,23 +11,18 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ExecutarImportacaoArquivoAcervoDocumentalUseCase : ServicoImportacaoArquivoBase, IExecutarImportacaoArquivoAcervoDocumentalUseCase, IImportacaoArquivoAcervoDocumentalAuxiliar 
+    public class ExecutarImportacaoArquivoAcervoDocumentalUseCase(
+        IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial, 
+        IServicoEditora servicoEditora, IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, 
+        IServicoAssunto servicoAssunto, IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, 
+        IServicoAcessoDocumento servicoAcessoDocumento, IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, 
+        IServicoFormato servicoFormato, IServicoAcervoDocumental servicoAcervoDocumental, IMapper mapper,
+        IRepositorioParametroSistema repositorioParametroSistema) : 
+        ServicoImportacaoArquivoBase(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, 
+            servicoIdioma, servicoAssunto, servicoCreditoAutor, servicoConservacao,servicoAcessoDocumento,servicoCromia,
+            servicoSuporte, servicoFormato, mapper,repositorioParametroSistema), 
+        IExecutarImportacaoArquivoAcervoDocumentalUseCase, IImportacaoArquivoAcervoDocumentalAuxiliar 
     {
-        private readonly IServicoAcervoDocumental servicoAcervoDocumental;
-        private readonly IMapper mapper;
-        
-        public ExecutarImportacaoArquivoAcervoDocumentalUseCase(IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial,
-            IServicoEditora servicoEditora,IServicoSerieColecao servicoSerieColecao,IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto,
-            IServicoCreditoAutor servicoCreditoAutor,IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
-            IServicoCromia servicoCromia, IServicoSuporte servicoSuporte,IServicoFormato servicoFormato,IServicoAcervoDocumental servicoAcervoDocumental,IMapper mapper,
-            IRepositorioParametroSistema repositorioParametroSistema)
-            : base(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor,
-                servicoConservacao,servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, mapper,repositorioParametroSistema)
-        {
-            this.servicoAcervoDocumental = servicoAcervoDocumental ?? throw new ArgumentNullException(nameof(servicoAcervoDocumental));
-            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())

--- a/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCase.cs
@@ -11,41 +11,46 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ExecutarImportacaoArquivoAcervoFotograficoUseCase(
-        IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial, IServicoEditora servicoEditora, 
-        IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto, 
-        IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
-        IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, IServicoFormato servicoFormato, 
-        IServicoAcervoFotografico servicoAcervoFotografico, IMapper mapper, IRepositorioParametroSistema repositorioParametroSistema) : 
-        ServicoImportacaoArquivoBase(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, servicoIdioma, 
-            servicoAssunto, servicoCreditoAutor, servicoConservacao,servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, 
-            mapper,repositorioParametroSistema), 
-        IExecutarImportacaoArquivoAcervoFotograficoUseCase,
-        IImportacaoArquivoAcervoFotograficoAuxiliar
+    public class ExecutarImportacaoArquivoAcervoFotograficoUseCase : ServicoImportacaoArquivoBase, IExecutarImportacaoArquivoAcervoFotograficoUseCase, IImportacaoArquivoAcervoFotograficoAuxiliar
     {
+        private readonly IServicoAcervoFotografico servicoAcervoFotografico;
+        private readonly IMapper mapper;
+
+        public ExecutarImportacaoArquivoAcervoFotograficoUseCase(IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial,
+            IServicoEditora servicoEditora, IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto,
+            IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
+            IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, IServicoFormato servicoFormato, IServicoAcervoFotografico servicoAcervoFotografico, IMapper mapper,
+            IRepositorioParametroSistema repositorioParametroSistema)
+            : base(repositorioImportacaoArquivo, servicoMaterial, servicoEditora, servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor,
+                servicoConservacao, servicoAcessoDocumento, servicoCromia, servicoSuporte, servicoFormato, mapper, repositorioParametroSistema)
+        {
+            this.servicoAcervoFotografico = servicoAcervoFotografico ?? throw new ArgumentNullException(nameof(servicoAcervoFotografico));
+            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())
                 throw new NegocioException(MensagemNegocio.PARAMETROS_INVALIDOS);
 
             long importacaoArquivoId = 0;
-            
-            if (!long.TryParse(param.Mensagem.ToString(),out importacaoArquivoId))
+
+            if (!long.TryParse(param.Mensagem.ToString(), out importacaoArquivoId))
                 throw new NegocioException(MensagemNegocio.PARAMETROS_INVALIDOS);
-            
+
             var importacaoArquivo = await repositorioImportacaoArquivo.ObterPorId(importacaoArquivoId);
-            
+
             if (importacaoArquivo.EhNulo())
                 throw new NegocioException(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
-            
+
             await CarregarDominiosFotograficos();
 
             var acervoFotograficoLinhaDtos = JsonConvert.DeserializeObject<IEnumerable<AcervoFotograficoLinhaDTO>>(importacaoArquivo.Conteudo);
-            
+
             ValidarPreenchimentoValorFormatoQtdeCaracteres(acervoFotograficoLinhaDtos);
-            
+
             await PersistenciaAcervo(acervoFotograficoLinhaDtos);
-            await AtualizarImportacao(importacaoArquivoId, JsonConvert.SerializeObject(acervoFotograficoLinhaDtos), acervoFotograficoLinhaDtos.Any(a=> a.PossuiErros) ? ImportacaoStatus.Erros : ImportacaoStatus.Sucesso);
+            await AtualizarImportacao(importacaoArquivoId, JsonConvert.SerializeObject(acervoFotograficoLinhaDtos), acervoFotograficoLinhaDtos.Any(a => a.PossuiErros) ? ImportacaoStatus.Erros : ImportacaoStatus.Sucesso);
 
             return true;
         }
@@ -53,17 +58,17 @@ namespace SME.CDEP.Aplicacao.Servicos
         public async Task CarregarDominiosFotograficos()
         {
             await CarregarTodosOsDominios();
-            
+
             await ObterCreditosAutoresPorTipo(TipoCreditoAutoria.Credito);
-                
+
             await ObterFormatosPorTipo(TipoFormato.ACERVO_FOTOS);
-            
+
             await ObterSuportesPorTipo(TipoSuporte.IMAGEM);
         }
 
         public async Task PersistenciaAcervo(IEnumerable<AcervoFotograficoLinhaDTO> acervosFotograficosLinhas)
         {
-            foreach (var acervoFotograficoLinha in acervosFotograficosLinhas.Where(w=> !w.PossuiErros))
+            foreach (var acervoFotograficoLinha in acervosFotograficosLinhas.Where(w => !w.PossuiErros))
             {
                 try
                 {
@@ -100,16 +105,16 @@ namespace SME.CDEP.Aplicacao.Servicos
                     acervoFotograficoLinha.DefinirLinhaComoErro(ex.Message);
                 }
             }
-        } 
-        
+        }
+
         public void ValidarPreenchimentoValorFormatoQtdeCaracteres(IEnumerable<AcervoFotograficoLinhaDTO> linhas)
         {
-            var creditos = CreditosAutores.Where(w => w.Tipo == (int)TipoCreditoAutoria.Credito).Select(s=> mapper.Map<IdNomeDTO>(s));
-            
-            var formatosFotos = Formatos.Where(w => w.Tipo == (int)TipoFormato.ACERVO_FOTOS).Select(s=> mapper.Map<IdNomeDTO>(s));
+            var creditos = CreditosAutores.Where(w => w.Tipo == (int)TipoCreditoAutoria.Credito).Select(s => mapper.Map<IdNomeDTO>(s));
 
-            var suporteImagens = Suportes.Where(w => w.Tipo == (int)TipoSuporte.IMAGEM).Select(s=> mapper.Map<IdNomeDTO>(s));
-            
+            var formatosFotos = Formatos.Where(w => w.Tipo == (int)TipoFormato.ACERVO_FOTOS).Select(s => mapper.Map<IdNomeDTO>(s));
+
+            var suporteImagens = Suportes.Where(w => w.Tipo == (int)TipoSuporte.IMAGEM).Select(s => mapper.Map<IdNomeDTO>(s));
+
             foreach (var linha in linhas)
             {
                 try
@@ -120,36 +125,36 @@ namespace SME.CDEP.Aplicacao.Servicos
                     ValidarPreenchimentoLimiteCaracteres(linha.Credito, Constantes.CREDITO);
                     ValidarConteudoCampoListaComDominio(linha.Credito, creditos, Constantes.CREDITO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Localizacao,Constantes.LOCALIZACAO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Procedencia,Constantes.PROCEDENCIA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Localizacao, Constantes.LOCALIZACAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Procedencia, Constantes.PROCEDENCIA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Ano,Constantes.ANO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Data,Constantes.DATA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Ano, Constantes.ANO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Data, Constantes.DATA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.CopiaDigital,Constantes.COPIA_DIGITAL);
-                    ValidarPreenchimentoLimiteCaracteres(linha.PermiteUsoImagem,Constantes.AUTORIZACAO_USO_DE_IMAGEM);
+                    ValidarPreenchimentoLimiteCaracteres(linha.CopiaDigital, Constantes.COPIA_DIGITAL);
+                    ValidarPreenchimentoLimiteCaracteres(linha.PermiteUsoImagem, Constantes.AUTORIZACAO_USO_DE_IMAGEM);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.EstadoConservacao,Constantes.ESTADO_CONSERVACAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.EstadoConservacao, Constantes.ESTADO_CONSERVACAO);
                     ValidarConteudoCampoComDominio(linha.EstadoConservacao, Conservacoes, Constantes.ESTADO_CONSERVACAO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Descricao,Constantes.DESCRICAO);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Quantidade,Constantes.QUANTIDADE);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Descricao, Constantes.DESCRICAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Quantidade, Constantes.QUANTIDADE);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Largura,Constantes.LARGURA);
-                    ValidarPreenchimentoLimiteCaracteres(linha.Altura,Constantes.ALTURA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Largura, Constantes.LARGURA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Altura, Constantes.ALTURA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Suporte,Constantes.SUPORTE);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Suporte, Constantes.SUPORTE);
                     ValidarConteudoCampoComDominio(linha.Suporte, suporteImagens, Constantes.SUPORTE);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.FormatoImagem,Constantes.FORMATO_IMAGEM);
+                    ValidarPreenchimentoLimiteCaracteres(linha.FormatoImagem, Constantes.FORMATO_IMAGEM);
                     ValidarConteudoCampoComDominio(linha.FormatoImagem, formatosFotos, Constantes.FORMATO_IMAGEM);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.TamanhoArquivo,Constantes.TAMANHO_ARQUIVO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.TamanhoArquivo, Constantes.TAMANHO_ARQUIVO);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Cromia,Constantes.CROMIA);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Cromia, Constantes.CROMIA);
                     ValidarConteudoCampoComDominio(linha.Cromia, Cromias, Constantes.CROMIA);
 
-                    ValidarPreenchimentoLimiteCaracteres(linha.Resolucao,Constantes.RESOLUCAO);
+                    ValidarPreenchimentoLimiteCaracteres(linha.Resolucao, Constantes.RESOLUCAO);
                     linha.PossuiErros = PossuiErro(linha);
                 }
                 catch (Exception e)
@@ -161,15 +166,15 @@ namespace SME.CDEP.Aplicacao.Servicos
 
         private bool PossuiErro(AcervoFotograficoLinhaDTO linha)
         {
-            return linha.Titulo.PossuiErro 
-                   || linha.Codigo.PossuiErro 
+            return linha.Titulo.PossuiErro
+                   || linha.Codigo.PossuiErro
                    || linha.Credito.PossuiErro
-                   || linha.Localizacao.PossuiErro 
+                   || linha.Localizacao.PossuiErro
                    || linha.Procedencia.PossuiErro
                    || linha.Ano.PossuiErro
                    || linha.Data.PossuiErro
-                   || linha.CopiaDigital.PossuiErro 
-                   || linha.PermiteUsoImagem.PossuiErro 
+                   || linha.CopiaDigital.PossuiErro
+                   || linha.PermiteUsoImagem.PossuiErro
                    || linha.EstadoConservacao.PossuiErro
                    || linha.Descricao.PossuiErro
                    || linha.Quantidade.PossuiErro
@@ -178,7 +183,7 @@ namespace SME.CDEP.Aplicacao.Servicos
                    || linha.Suporte.PossuiErro
                    || linha.FormatoImagem.PossuiErro
                    || linha.TamanhoArquivo.PossuiErro
-                   || linha.Cromia.PossuiErro 
+                   || linha.Cromia.PossuiErro
                    || linha.Resolucao.PossuiErro;
         }
     }

--- a/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCase.cs
@@ -11,23 +11,18 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ExecutarImportacaoArquivoAcervoFotograficoUseCase : ServicoImportacaoArquivoBase, IExecutarImportacaoArquivoAcervoFotograficoUseCase,IImportacaoArquivoAcervoFotograficoAuxiliar
+    public class ExecutarImportacaoArquivoAcervoFotograficoUseCase(
+        IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial, IServicoEditora servicoEditora, 
+        IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto, 
+        IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
+        IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, IServicoFormato servicoFormato, 
+        IServicoAcervoFotografico servicoAcervoFotografico, IMapper mapper, IRepositorioParametroSistema repositorioParametroSistema) : 
+        ServicoImportacaoArquivoBase(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, servicoIdioma, 
+            servicoAssunto, servicoCreditoAutor, servicoConservacao,servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, 
+            mapper,repositorioParametroSistema), 
+        IExecutarImportacaoArquivoAcervoFotograficoUseCase,
+        IImportacaoArquivoAcervoFotograficoAuxiliar
     {
-        private readonly IServicoAcervoFotografico servicoAcervoFotografico;
-        private readonly IMapper mapper;
-        
-        public ExecutarImportacaoArquivoAcervoFotograficoUseCase(IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial,
-            IServicoEditora servicoEditora,IServicoSerieColecao servicoSerieColecao,IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto,
-            IServicoCreditoAutor servicoCreditoAutor,IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
-            IServicoCromia servicoCromia, IServicoSuporte servicoSuporte,IServicoFormato servicoFormato,IServicoAcervoFotografico servicoAcervoFotografico,IMapper mapper,
-            IRepositorioParametroSistema repositorioParametroSistema)
-            : base(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor,
-                servicoConservacao,servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, mapper,repositorioParametroSistema)
-        {
-            this.servicoAcervoFotografico = servicoAcervoFotografico ?? throw new ArgumentNullException(nameof(servicoAcervoFotografico));
-            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())

--- a/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoTridimensionalUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoTridimensionalUseCase.cs
@@ -11,23 +11,18 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao.Servicos
 {
-    public class ExecutarImportacaoArquivoAcervoTridimensionalUseCase : ServicoImportacaoArquivoBase, IExecutarImportacaoArquivoAcervoTridimensionalUseCase, IImportacaoArquivoAcervoTridimensionalAuxiliar
+    public class ExecutarImportacaoArquivoAcervoTridimensionalUseCase(
+        IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial, 
+        IServicoEditora servicoEditora, IServicoSerieColecao servicoSerieColecao, IServicoIdioma servicoIdioma, 
+        IServicoAssunto servicoAssunto, IServicoCreditoAutor servicoCreditoAutor, IServicoConservacao servicoConservacao, 
+        IServicoAcessoDocumento servicoAcessoDocumento, IServicoCromia servicoCromia, IServicoSuporte servicoSuporte, 
+        IServicoFormato servicoFormato, IServicoAcervoTridimensional servicoAcervoTridimensional, IMapper mapper,
+        IRepositorioParametroSistema repositorioParametroSistema) : 
+        ServicoImportacaoArquivoBase(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,
+            servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor, servicoConservacao,
+            servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, mapper,repositorioParametroSistema), 
+        IExecutarImportacaoArquivoAcervoTridimensionalUseCase, IImportacaoArquivoAcervoTridimensionalAuxiliar
     {
-        private readonly IServicoAcervoTridimensional servicoAcervoTridimensional;
-        private readonly IMapper mapper;
-        
-        public ExecutarImportacaoArquivoAcervoTridimensionalUseCase(IRepositorioImportacaoArquivo repositorioImportacaoArquivo, IServicoMaterial servicoMaterial,
-            IServicoEditora servicoEditora,IServicoSerieColecao servicoSerieColecao,IServicoIdioma servicoIdioma, IServicoAssunto servicoAssunto,
-            IServicoCreditoAutor servicoCreditoAutor,IServicoConservacao servicoConservacao, IServicoAcessoDocumento servicoAcessoDocumento,
-            IServicoCromia servicoCromia, IServicoSuporte servicoSuporte,IServicoFormato servicoFormato,IServicoAcervoTridimensional servicoAcervoTridimensional,IMapper mapper,
-            IRepositorioParametroSistema repositorioParametroSistema)
-            : base(repositorioImportacaoArquivo, servicoMaterial, servicoEditora,servicoSerieColecao, servicoIdioma, servicoAssunto, servicoCreditoAutor,
-                servicoConservacao,servicoAcessoDocumento,servicoCromia,servicoSuporte, servicoFormato, mapper,repositorioParametroSistema)
-        {
-            this.servicoAcervoTridimensional = servicoAcervoTridimensional ?? throw new ArgumentNullException(nameof(servicoAcervoTridimensional));
-            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())

--- a/src/SME.CDEP.Aplicacao/UseCase/NotificacaoEmailBaseUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/NotificacaoEmailBaseUseCase.cs
@@ -1,7 +1,7 @@
 using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
-using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.Aplicacao
 {

--- a/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase.cs
@@ -11,20 +11,9 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao
 {
-    public class NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase : INotificarViaEmailCancelamentoAtendimentoItemUseCase
+    public class NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
+        IServicoNotificacaoEmail servicoNotificacaoEmail, IRepositorioParametroSistema repositorioParametroSistema) : INotificarViaEmailCancelamentoAtendimentoItemUseCase
     {
-        private IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem;
-        private IServicoNotificacaoEmail servicoNotificacaoEmail;
-        private IRepositorioParametroSistema repositorioParametroSistema;
-        
-        public NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
-            IServicoNotificacaoEmail servicoNotificacaoEmail,IRepositorioParametroSistema repositorioParametroSistema)
-        {
-            this.repositorioAcervoSolicitacaoItem = repositorioAcervoSolicitacaoItem ?? throw new ArgumentNullException(nameof(repositorioAcervoSolicitacaoItem));
-            this.servicoNotificacaoEmail = servicoNotificacaoEmail ?? throw new ArgumentNullException(nameof(servicoNotificacaoEmail));
-            this.repositorioParametroSistema = repositorioParametroSistema ?? throw new ArgumentNullException(nameof(repositorioParametroSistema));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())
@@ -37,13 +26,13 @@ namespace SME.CDEP.Aplicacao
 
             var detalhesAcervo = await repositorioAcervoSolicitacaoItem.ObterDetalhamentoDosItensPorSolicitacaoOuItem(null,acervoSolicitacaoItemId);
 
-            if (detalhesAcervo.Any(a=> a.Email.NaoEstaPreenchido()))
+            if (detalhesAcervo.Any(a=> string.IsNullOrWhiteSpace(a.Email)))
                 throw new NegocioException(MensagemNegocio.SOLICITANTE_NAO_POSSUI_EMAIL);
             
-            if (detalhesAcervo.NaoPossuiElementos())
+            if (detalhesAcervo is null || !detalhesAcervo.Any())
                 throw new NegocioException(MensagemNegocio.SOLICITACAO_ATENDIMENTO_NAO_CONTEM_ACERVOS);
             
-            var destinatario = detalhesAcervo.FirstOrDefault().Solicitante;
+            var destinatario = detalhesAcervo.First().Solicitante!;
             
             var anoAtual = DateTimeExtension.HorarioBrasilia().Year;
 
@@ -53,15 +42,15 @@ namespace SME.CDEP.Aplicacao
             
             var textoEmail = modeloEmail
                 .Replace("#NOME", destinatario)
-                .Replace("#CONTEUDO_TABELA", GerarConteudoTabela(detalhesAcervo.FirstOrDefault()))
+                .Replace("#CONTEUDO_TABELA", GerarConteudoTabela(detalhesAcervo.First()))
                 .Replace("#LINK_FORMULARIO_CDEP", enderecoContatoCDEP);
             
-            await servicoNotificacaoEmail.Enviar(destinatario, detalhesAcervo.FirstOrDefault().Email, "CDEP - Atendimento item cancelado", textoEmail);
+            await servicoNotificacaoEmail.Enviar(destinatario, detalhesAcervo.First().Email!, "CDEP - Atendimento item cancelado", textoEmail);
             
             return true;
         }
         
-        private string GerarConteudoTabela(AcervoSolicitacaoItemDetalhe detalhe)
+        private static string GerarConteudoTabela(AcervoSolicitacaoItemDetalhe detalhe)
         {
             var conteudo = new StringBuilder();
 

--- a/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase.cs
@@ -11,20 +11,9 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao
 {
-    public class NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase : INotificarViaEmailCancelamentoAtendimentoUseCase
+    public class NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
+        IServicoNotificacaoEmail servicoNotificacaoEmail, IRepositorioParametroSistema repositorioParametroSistema) : INotificarViaEmailCancelamentoAtendimentoUseCase
     {
-        private IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem;
-        private IServicoNotificacaoEmail servicoNotificacaoEmail;
-        private IRepositorioParametroSistema repositorioParametroSistema;
-        
-        public NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
-            IServicoNotificacaoEmail servicoNotificacaoEmail,IRepositorioParametroSistema repositorioParametroSistema)
-        {
-            this.repositorioAcervoSolicitacaoItem = repositorioAcervoSolicitacaoItem ?? throw new ArgumentNullException(nameof(repositorioAcervoSolicitacaoItem));
-            this.servicoNotificacaoEmail = servicoNotificacaoEmail ?? throw new ArgumentNullException(nameof(servicoNotificacaoEmail));
-            this.repositorioParametroSistema = repositorioParametroSistema ?? throw new ArgumentNullException(nameof(repositorioParametroSistema));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             if (param.Mensagem.EhNulo())
@@ -61,7 +50,7 @@ namespace SME.CDEP.Aplicacao
             return true;
         }
         
-        private string GerarConteudoTabela(IEnumerable<AcervoSolicitacaoItemDetalhe> detalhesAcervo)
+        private static string GerarConteudoTabela(IEnumerable<AcervoSolicitacaoItemDetalhe> detalhesAcervo)
         {
             var conteudo = new StringBuilder();
 

--- a/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase.cs
+++ b/src/SME.CDEP.Aplicacao/UseCase/NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase.cs
@@ -12,20 +12,9 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 
 namespace SME.CDEP.Aplicacao
 {
-    public class NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase : INotificarViaEmailConfirmacaoAtendimentoPresencialUseCase
+    public class NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
+        IServicoNotificacaoEmail servicoNotificacaoEmail, IRepositorioParametroSistema repositorioParametroSistema) : INotificarViaEmailConfirmacaoAtendimentoPresencialUseCase
     {
-        private IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem;
-        private IServicoNotificacaoEmail servicoNotificacaoEmail;
-        private IRepositorioParametroSistema repositorioParametroSistema;
-        
-        public NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase(IRepositorioAcervoSolicitacaoItem repositorioAcervoSolicitacaoItem,
-            IServicoNotificacaoEmail servicoNotificacaoEmail,IRepositorioParametroSistema repositorioParametroSistema)
-        {
-            this.repositorioAcervoSolicitacaoItem = repositorioAcervoSolicitacaoItem ?? throw new ArgumentNullException(nameof(repositorioAcervoSolicitacaoItem));
-            this.servicoNotificacaoEmail = servicoNotificacaoEmail ?? throw new ArgumentNullException(nameof(servicoNotificacaoEmail));
-            this.repositorioParametroSistema = repositorioParametroSistema ?? throw new ArgumentNullException(nameof(repositorioParametroSistema));
-        }
-
         public async Task<bool> Executar(MensagemRabbit param)
         {
             var confirmarAtendimentoDto = param.ObterObjetoMensagem<ConfirmarAtendimentoDTO>();
@@ -68,7 +57,7 @@ namespace SME.CDEP.Aplicacao
             return true;
         }
         
-        private string GerarConteudoTabela(IEnumerable<AcervoSolicitacaoItemDetalhe> detalhes)
+        private static string GerarConteudoTabela(IEnumerable<AcervoSolicitacaoItemDetalhe> detalhes)
         {
             var conteudo = new StringBuilder();
 

--- a/src/SME.CDEP.Dominio/Entidades/Usuario.cs
+++ b/src/SME.CDEP.Dominio/Entidades/Usuario.cs
@@ -1,4 +1,5 @@
-﻿using SME.CDEP.Infra.Dominio.Enumerados;
+﻿using SME.CDEP.Dominio.Extensions;
+using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.Dominio.Entidades
 {

--- a/src/SME.CDEP.Dominio/Extensions/DateTimeExtension.cs
+++ b/src/SME.CDEP.Dominio/Extensions/DateTimeExtension.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using SME.CDEP.Dominio.Extensions;
 
-namespace SME.CDEP.Infra.Dominio.Enumerados
+namespace SME.CDEP.Dominio.Extensions
 {
     public static class DateTimeExtension
     {

--- a/src/SME.CDEP.Dominio/Extensions/IntExtension.cs
+++ b/src/SME.CDEP.Dominio/Extensions/IntExtension.cs
@@ -1,7 +1,4 @@
-﻿
-using SME.CDEP.Infra.Dominio.Enumerados;
-
-namespace SME.CDEP.Dominio.Extensions
+﻿namespace SME.CDEP.Dominio.Extensions
 {
     public static class IntExtension
     {

--- a/src/SME.CDEP.Infra.Dados/CdepConexao.cs
+++ b/src/SME.CDEP.Infra.Dados/CdepConexao.cs
@@ -1,8 +1,10 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql;
 
 namespace SME.CDEP.Infra.Dados;
 
+[ExcludeFromCodeCoverage]
 public class CdepConexao : ICdepConexao
 {
         private readonly IDbConnection _conexao; 

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoArteGraficaArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoArteGraficaArquivo.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoArteGraficaArquivo : RepositorioBaseSomenteId<AcervoArteGraficaArquivo>, IRepositorioAcervoArteGraficaArquivo
     {
         public RepositorioAcervoArteGraficaArquivo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoBibliograficoAssunto.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoBibliograficoAssunto.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoBibliograficoAssunto : RepositorioBaseSomenteId<AcervoBibliograficoAssunto>, IRepositorioAcervoBibliograficoAssunto
     {
         public RepositorioAcervoBibliograficoAssunto(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumental.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumental.cs
@@ -3,9 +3,11 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoDocumental : RepositorioBase<AcervoDocumental>, IRepositorioAcervoDocumental
     {
         public RepositorioAcervoDocumental(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumentalAcessoDocumento.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumentalAcessoDocumento.cs
@@ -2,9 +2,12 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoDocumentalAcessoDocumento : RepositorioBaseSomenteId<AcervoDocumentalAcessoDocumento>, IRepositorioAcervoDocumentalAcessoDocumento
     {
         public RepositorioAcervoDocumentalAcessoDocumento(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumentalArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoDocumentalArquivo.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoDocumentalArquivo : RepositorioBaseSomenteId<AcervoDocumentalArquivo>, IRepositorioAcervoDocumentalArquivo
     {
         public RepositorioAcervoDocumentalArquivo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoEmprestimo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoEmprestimo.cs
@@ -1,6 +1,7 @@
 ﻿using Dapper;
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
 

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoFotograficoArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoFotograficoArquivo.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoFotograficoArquivo : RepositorioBaseSomenteId<AcervoFotograficoArquivo>, IRepositorioAcervoFotograficoArquivo
     {
         public RepositorioAcervoFotograficoArquivo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoSolicitacao.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoSolicitacao.cs
@@ -4,9 +4,11 @@ using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoSolicitacao : RepositorioBaseAuditavel<AcervoSolicitacao>, IRepositorioAcervoSolicitacao
     {
         public RepositorioAcervoSolicitacao(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoSolicitacaoItem.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoSolicitacaoItem.cs
@@ -1,6 +1,7 @@
 ﻿using Dapper;
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using System.Diagnostics.CodeAnalysis;

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoTridimensionalArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcervoTridimensionalArquivo.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcervoTridimensionalArquivo : RepositorioBaseSomenteId<AcervoTridimensionalArquivo>, IRepositorioAcervoTridimensionalArquivo
     {
         public RepositorioAcervoTridimensionalArquivo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcessoDocumento.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAcessoDocumento.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAcessoDocumento : RepositorioBase<AcessoDocumento>, IRepositorioAcessoDocumento
     {
         public RepositorioAcessoDocumento(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioArquivo.cs
@@ -6,9 +6,11 @@ using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioArquivo : RepositorioBaseAuditavel<Arquivo>, IRepositorioArquivo
     {
         private readonly IContextoAplicacao contextoAplicacao;

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAssunto.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioAssunto.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioAssunto : RepositorioBase<Assunto>, IRepositorioAssunto
     {
         public RepositorioAssunto(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioBase.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioBase.cs
@@ -6,9 +6,11 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Excecoes;
 using SME.CDEP.Dominio.Repositorios;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios;
 
+[ExcludeFromCodeCoverage]
 public abstract class RepositorioBase<TEntidade> : IRepositorioBase<TEntidade>
     where TEntidade : EntidadeBase    
 {

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioBaseAuditavel.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioBaseAuditavel.cs
@@ -1,8 +1,8 @@
 using Dommel;
 using SME.CDEP.Dominio;
 using SME.CDEP.Dominio.Contexto;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Dominio.Repositorios;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios;

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioConservacao.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioConservacao.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioConservacao : RepositorioBase<Conservacao>, IRepositorioConservacao
     {
         public RepositorioConservacao(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioCreditoAutor.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioCreditoAutor.cs
@@ -3,9 +3,11 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioCreditoAutor : RepositorioBase<CreditoAutor>, IRepositorioCreditoAutor
     {
         public RepositorioCreditoAutor(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto, conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioCromia.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioCromia.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioCromia : RepositorioBase<Cromia>, IRepositorioCromia
     {
         public RepositorioCromia(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEditora.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEditora.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioEditora : RepositorioBase<Editora>, IRepositorioEditora
     {
         public RepositorioEditora(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEvento.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEvento.cs
@@ -3,9 +3,11 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioEvento : RepositorioBaseAuditavel<Evento>, IRepositorioEvento
     {
         public RepositorioEvento(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEventoFixo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioEventoFixo.cs
@@ -1,9 +1,11 @@
 ﻿using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioEventoFixo : RepositorioBaseAuditavel<EventoFixo>, IRepositorioEventoFixo
     {
         public RepositorioEventoFixo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioFormato.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioFormato.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioFormato : RepositorioBase<Formato>, IRepositorioFormato
     {
         public RepositorioFormato(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioIdioma.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioIdioma.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioIdioma : RepositorioBase<Idioma>, IRepositorioIdioma
     {
         public RepositorioIdioma(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioImportacaoArquivo.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioImportacaoArquivo.cs
@@ -4,9 +4,11 @@ using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioImportacaoArquivo : RepositorioBaseAuditavel<ImportacaoArquivo>, IRepositorioImportacaoArquivo
     {
         public RepositorioImportacaoArquivo(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioMaterial.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioMaterial.cs
@@ -3,9 +3,11 @@ using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioMaterial : RepositorioBase<Material>, IRepositorioMaterial
     {
         public RepositorioMaterial(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioSerieColecao.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioSerieColecao.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioSerieColecao : RepositorioBase<SerieColecao>, IRepositorioSerieColecao
     {
         public RepositorioSerieColecao(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioSuporte.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioSuporte.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioSuporte : RepositorioBase<Suporte>, IRepositorioSuporte
     {
         public RepositorioSuporte(IContextoAplicacao contexto, ICdepConexao conexao) : base(contexto,conexao)

--- a/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioUsuario.cs
+++ b/src/SME.CDEP.Infra.Dados/Repositorios/RepositorioUsuario.cs
@@ -2,9 +2,11 @@
 using SME.CDEP.Dominio.Contexto;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados.Repositorios
 {
+    [ExcludeFromCodeCoverage]
     public class RepositorioUsuario(IContextoAplicacao contexto, ICdepConexao conexao) : RepositorioBaseAuditavel<Usuario>(contexto, conexao), IRepositorioUsuario
     {
         public Task<Usuario?> ObterPorLogin(string login)

--- a/src/SME.CDEP.Infra.Dados/Transacao.cs
+++ b/src/SME.CDEP.Infra.Dados/Transacao.cs
@@ -1,7 +1,9 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Dados;
 
+[ExcludeFromCodeCoverage]
 public class Transacao : ITransacao
 {
     private readonly ICdepConexao _conexao;

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/ConexoesRabbit.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/ConexoesRabbit.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Extensions.ObjectPool;
 using RabbitMQ.Client;
 using SME.CDEP.Infra.Servicos.Options;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Servicos.Mensageria
 {
+    [ExcludeFromCodeCoverage]
     public class ConexoesRabbit : IConexoesRabbit
     {
         public ObjectPool<IModel> pool { get; set; }

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/Exchange/ExchangeRabbit.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/Exchange/ExchangeRabbit.cs
@@ -1,5 +1,8 @@
-﻿namespace SME.CDEP.Infra.Servicos.Mensageria.Exchange
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SME.CDEP.Infra.Servicos.Mensageria.Exchange
 {
+    [ExcludeFromCodeCoverage]
     public static class ExchangeRabbit
     {
         public static string Logs = "EnterpriseApplicationLog";

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/IoC/MensageriaIoCHelper.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/IoC/MensageriaIoCHelper.cs
@@ -2,9 +2,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using SME.CDEP.Infra.Servicos.Mensageria.Options;
 using SME.ConectaFormacao.Infra.Servicos.Mensageria;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Servicos.Mensageria.IoC
 {
+    [ExcludeFromCodeCoverage]
     public static class MensageriaIoCHelper
     {
         public static void ConfigurarMensageria(this IServiceCollection services, IConfiguration configuration)

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/Log/LogMensagem.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/Log/LogMensagem.cs
@@ -1,5 +1,8 @@
-﻿namespace SME.CDEP.Infra.Servicos.Mensageria.Log
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SME.CDEP.Infra.Servicos.Mensageria.Log
 {
+    [ExcludeFromCodeCoverage]
     public class LogMensagem 
     {
         public LogMensagem(string mensagem, string contexto = "", string nivel = "", string observacao = "", string rastreamento = "", string projeto = "CDEP")

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/Log/ServicoLogs.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/Log/ServicoLogs.cs
@@ -1,13 +1,15 @@
 ﻿using Newtonsoft.Json;
 using Polly;
 using Polly.Registry;
-using System.Text;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.Mensageria.Exchange;
 using SME.CDEP.Infra.Servicos.Polly;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace SME.CDEP.Infra.Servicos.Mensageria.Log
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoLogs : IServicoLogs
     {
         private readonly IConexoesRabbitLogs conexoesRabbit;

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/MensagemRabbitLogs.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/MensagemRabbitLogs.cs
@@ -1,5 +1,8 @@
-﻿namespace SME.CDEP.Infra.Servicos.Mensageria
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SME.CDEP.Infra.Servicos.Mensageria
 {
+    [ExcludeFromCodeCoverage]
     public class MensagemRabbitLogs
     {
         public MensagemRabbitLogs(string mensagem)

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaCDEP.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaCDEP.cs
@@ -7,9 +7,11 @@ using SME.CDEP.Infra.Servicos.Mensageria;
 using SME.CDEP.Infra.Servicos.Polly;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.Infra.Servicos.Telemetria;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.ConectaFormacao.Infra.Servicos.Mensageria
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoMensageriaCDEP : IServicoMensageriaCDEP
     {
         private readonly IConexoesRabbit conexaoRabbit;

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaLogs.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaLogs.cs
@@ -3,9 +3,11 @@ using Polly;
 using Polly.Registry;
 using System.Text;
 using SME.CDEP.Infra.Servicos.Polly;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Servicos.Mensageria
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoMensageriaLogs : IServicoMensageriaLogs
     {
         private readonly IConexoesRabbitLogs conexoesRabbit;

--- a/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaMetricas.cs
+++ b/src/SME.CDEP.Infra.Servicos/Mensageria/ServicoMensageriaMetricas.cs
@@ -9,9 +9,11 @@ using SME.CDEP.Infra.Servicos.Mensageria.Log;
 using SME.CDEP.Infra.Servicos.Polly;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.Infra.Servicos.Telemetria;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Servicos.Mensageria
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoMensageriaMetricas : IServicoMensageriaMetricas
     {
         private readonly IConexoesRabbit conexaoRabbit;

--- a/src/SME.CDEP.Infra.Servicos/Rabbit/DTO/MetricaMensageria.cs
+++ b/src/SME.CDEP.Infra.Servicos/Rabbit/DTO/MetricaMensageria.cs
@@ -1,4 +1,4 @@
-﻿using SME.CDEP.Infra.Dominio.Enumerados;
+﻿using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.Infra.Servicos.Rabbit.Dto
 {

--- a/src/SME.CDEP.Infra.Servicos/Telemetria/ServicoTelemetria.cs
+++ b/src/SME.CDEP.Infra.Servicos/Telemetria/ServicoTelemetria.cs
@@ -2,9 +2,11 @@
 using Elastic.Apm.Api;
 using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Servicos.Telemetria.Options;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra.Servicos.Telemetria
 {
+    [ExcludeFromCodeCoverage]
     public class ServicoTelemetria : IServicoTelemetria
     {
         private readonly TelemetriaOptions _telemetriaOptions;

--- a/src/SME.CDEP.Infra.Servicos/Worker/WorkerRabbitCDEP.cs
+++ b/src/SME.CDEP.Infra.Servicos/Worker/WorkerRabbitCDEP.cs
@@ -15,9 +15,11 @@ using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.Infra.Servicos.Telemetria;
 using SME.CDEP.Infra.Servicos.Telemetria.Options;
 using SME.CDEP.Infra.Servicos.Utilitarios;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Infra
 {
+    [ExcludeFromCodeCoverage]
     public abstract class WorkerRabbitCDEP : IHostedService
     {
         protected readonly IModel canalRabbit;

--- a/src/SME.CDEP.IoC/Extensions/RegistrarHttpClients.cs
+++ b/src/SME.CDEP.IoC/Extensions/RegistrarHttpClients.cs
@@ -4,33 +4,36 @@ using Polly;
 using Polly.Extensions.Http;
 using SME.CDEP.Aplicacao.Integracoes;
 using SME.CDEP.Aplicacao.Integracoes.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.IoC.Extensions;
 
-    internal static class RegistrarHttpClients
+[ExcludeFromCodeCoverage]
+internal static class RegistrarHttpClients
+{
+    internal static void AdicionarHttpClients(this IServiceCollection services, IConfiguration configuration)
     {
-        internal static void AdicionarHttpClients(this IServiceCollection services, IConfiguration configuration)
+        services.AddHttpClient<IServicoAcessos, ServicoAcessos>(c =>
+         {
+             c.BaseAddress = new Uri(configuration.GetSection("UrlApiAcessos").Value);
+             c.DefaultRequestHeaders.Add("Accept", "application/json");
+             c.DefaultRequestHeaders.Add("x-api-acessos-key", configuration.GetSection("ApiKeyAcessosApi").Value);
+         });
+
+        services.AddHttpClient(name: "servicoAcessos", c =>
         {
-           services.AddHttpClient<IServicoAcessos, ServicoAcessos>(c =>
-            {
-                c.BaseAddress = new Uri(configuration.GetSection("UrlApiAcessos").Value);
-                c.DefaultRequestHeaders.Add("Accept", "application/json");
-                c.DefaultRequestHeaders.Add("x-api-acessos-key", configuration.GetSection("ApiKeyAcessosApi").Value);
-            });
+            c.BaseAddress = new Uri(configuration.GetSection("UrlApiAcessos").Value);
+            c.DefaultRequestHeaders.Add("Accept", "application/json");
+            c.DefaultRequestHeaders.Add("x-api-acessos-key", configuration.GetSection("ApiKeyAcessosApi").Value);
 
-            services.AddHttpClient(name: "servicoAcessos", c =>
-            {
-                c.BaseAddress = new Uri(configuration.GetSection("UrlApiAcessos").Value);
-                c.DefaultRequestHeaders.Add("Accept", "application/json");
-                c.DefaultRequestHeaders.Add("x-api-acessos-key", configuration.GetSection("ApiKeyAcessosApi").Value);
-
-            }).AddPolicyHandler(GetRetryPolicy());
-        }
-
-        private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
-        {
-            return HttpPolicyExtensions
-                .HandleTransientHttpError()
-                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)));
-        }
+        }).AddPolicyHandler(GetRetryPolicy());
+        services.AddHttpClient();
     }
+
+    private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)));
+    }
+}

--- a/src/SME.CDEP.IoC/RegistradorDeDependencia.cs
+++ b/src/SME.CDEP.IoC/RegistradorDeDependencia.cs
@@ -27,9 +27,11 @@ using SME.CDEP.Infra.Servicos.ServicoArmazenamento;
 using SME.CDEP.Infra.Servicos.ServicoArmazenamento.Interface;
 using SME.CDEP.Infra.Servicos.Telemetria.IoC;
 using SME.CDEP.IoC.Extensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.IoC;
 
+[ExcludeFromCodeCoverage]
 public class RegistradorDeDependencia
 {
     private readonly IServiceCollection _serviceCollection;

--- a/src/SME.CDEP.Webapi/Controllers/EventoController.cs
+++ b/src/SME.CDEP.Webapi/Controllers/EventoController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Webapi.Controllers.Filtros;
 using SME.CDEP.Webapi.Filtros;

--- a/src/SME.CDEP.Webapi/Middlewares/TratamentoExcecaoGlobalMiddleware.cs
+++ b/src/SME.CDEP.Webapi/Middlewares/TratamentoExcecaoGlobalMiddleware.cs
@@ -4,9 +4,11 @@ using Newtonsoft.Json.Serialization;
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Excecoes;
 using SME.CDEP.Infra.Servicos.Mensageria.Log;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Webapi.Middlewares
 {
+    [ExcludeFromCodeCoverage]
     public class TratamentoExcecaoGlobalMiddleware(RequestDelegate next, IServicoLogs servicoLogs)
     {
         private readonly IServicoLogs servicoLogs = servicoLogs ?? throw new ArgumentNullException(nameof(servicoLogs));
@@ -46,6 +48,7 @@ namespace SME.CDEP.Webapi.Middlewares
         }
     }
 
+    [ExcludeFromCodeCoverage]
     public static class TratamentoExcecaoGlobalMiddlewareExtensions
     {
         public static IApplicationBuilder UseTratamentoExcecoesGlobalMiddleware(this IApplicationBuilder builder)

--- a/src/SME.CDEP.Worker/WorkerRabbitMQ.cs
+++ b/src/SME.CDEP.Worker/WorkerRabbitMQ.cs
@@ -6,9 +6,11 @@ using SME.CDEP.Infra;
 using SME.CDEP.Infra.Servicos.Mensageria;
 using SME.CDEP.Infra.Servicos.Telemetria;
 using SME.CDEP.Infra.Servicos.Telemetria.Options;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SME.CDEP.Worker
 {
+    [ExcludeFromCodeCoverage]
     public sealed class WorkerRabbitMQ : WorkerRabbitCDEP
     {
         public WorkerRabbitMQ(IServiceScopeFactory serviceScopeFactory,

--- a/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_fazer_manutencao_acervo_emprestimo.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_fazer_manutencao_acervo_emprestimo.cs
@@ -2,6 +2,7 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_devolucao_emprestimo_atrasado.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_devolucao_emprestimo_atrasado.cs
@@ -2,6 +2,7 @@
 using Shouldly;
 using SME.CDEP.Aplicacao;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.TesteIntegracao.Setup;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_devolucao_emprestimo_atrasado_prolongado.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_devolucao_emprestimo_atrasado_prolongado.cs
@@ -2,6 +2,7 @@
 using Shouldly;
 using SME.CDEP.Aplicacao;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.TesteIntegracao.Setup;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_vencimento_emprestimo.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoEmprestimo/Ao_notificar_vencimento_emprestimo.cs
@@ -2,6 +2,7 @@
 using Shouldly;
 using SME.CDEP.Aplicacao;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.TesteIntegracao.Setup;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_alterar_acervo_solicitacao_manual.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_alterar_acervo_solicitacao_manual.cs
@@ -3,6 +3,7 @@ using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Constantes;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_alterar_data_visita_acervo_solicitacao_item.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_alterar_data_visita_acervo_solicitacao_item.cs
@@ -2,6 +2,7 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_atualizar_situacao_para_emprestimo_com_devolucao_em_atraso.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_atualizar_situacao_para_emprestimo_com_devolucao_em_atraso.cs
@@ -1,6 +1,7 @@
 ﻿using Shouldly;
 using SME.CDEP.Aplicacao;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.Infra.Servicos.Rabbit.Dto;
 using SME.CDEP.TesteIntegracao.Setup;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_cancelar_acervo_solicitacao.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_cancelar_acervo_solicitacao.cs
@@ -2,6 +2,7 @@
 using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_cancelar_acervo_solicitacao_item.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_cancelar_acervo_solicitacao_item.cs
@@ -2,6 +2,7 @@
 using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_inserir_acervo_solicitacao_manual.cs
+++ b/teste/SME.CDEP.TesteIntegracao/AcervoSolicitacao/Ao_inserir_acervo_solicitacao_manual.cs
@@ -2,6 +2,7 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using Xunit;

--- a/teste/SME.CDEP.TesteIntegracao/Assunto/Ao_fazer_manutencao_assunto.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Assunto/Ao_fazer_manutencao_assunto.cs
@@ -2,10 +2,10 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao
 {

--- a/teste/SME.CDEP.TesteIntegracao/CreditoAutor/Ao_fazer_manutencao_credito_autor.cs
+++ b/teste/SME.CDEP.TesteIntegracao/CreditoAutor/Ao_fazer_manutencao_credito_autor.cs
@@ -6,6 +6,7 @@ using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao
 {

--- a/teste/SME.CDEP.TesteIntegracao/Editora/Ao_fazer_manutencao_editora.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Editora/Ao_fazer_manutencao_editora.cs
@@ -2,10 +2,10 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao
 {

--- a/teste/SME.CDEP.TesteIntegracao/Eventos/Ao_gerar_evento_fixos_moveis.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Eventos/Ao_gerar_evento_fixos_moveis.cs
@@ -1,8 +1,8 @@
 ﻿using Shouldly;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.TesteIntegracao.Setup;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao.Eventos
 {

--- a/teste/SME.CDEP.TesteIntegracao/Mocks/AcervoArteGraficaDTOMock.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Mocks/AcervoArteGraficaDTOMock.cs
@@ -1,7 +1,6 @@
 ﻿using Bogus;
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Extensions;
-using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.TesteIntegracao;
 

--- a/teste/SME.CDEP.TesteIntegracao/Mocks/AcervoSolicitacaoMock.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Mocks/AcervoSolicitacaoMock.cs
@@ -1,5 +1,6 @@
 ﻿using Bogus;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.Infra.Dominio.Enumerados;
 
 namespace SME.CDEP.TesteIntegracao;

--- a/teste/SME.CDEP.TesteIntegracao/Mocks/AuditoriaMock.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Mocks/AuditoriaMock.cs
@@ -1,6 +1,6 @@
 ﻿using Bogus;
 using SME.CDEP.Dominio;
-using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao;
 

--- a/teste/SME.CDEP.TesteIntegracao/Mocks/ParametroSistemaMock.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Mocks/ParametroSistemaMock.cs
@@ -1,6 +1,6 @@
 ﻿using Bogus;
 using SME.CDEP.Dominio.Entidades;
-using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao;
 

--- a/teste/SME.CDEP.TesteIntegracao/SerieColecao/Ao_fazer_manutencao_serie_colecao.cs
+++ b/teste/SME.CDEP.TesteIntegracao/SerieColecao/Ao_fazer_manutencao_serie_colecao.cs
@@ -2,10 +2,10 @@
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Dominio.Entidades;
 using SME.CDEP.Dominio.Excecoes;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao
 {

--- a/teste/SME.CDEP.TesteIntegracao/ServicosFakes/ServicoAcessosFake.cs
+++ b/teste/SME.CDEP.TesteIntegracao/ServicosFakes/ServicoAcessosFake.cs
@@ -1,7 +1,7 @@
 ﻿using Bogus;
 using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Aplicacao.Integracoes.Interfaces;
-using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Dominio.Extensions;
 using SME.CDEP.TesteIntegracao.Constantes;
 
 namespace SME.CDEP.TesteIntegracao.ServicosFakes;

--- a/teste/SME.CDEP.TesteIntegracao/Usuarios/Ao_fazer_autenticacao.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Usuarios/Ao_fazer_autenticacao.cs
@@ -6,9 +6,9 @@ using SME.CDEP.Aplicacao.Servicos.Interface;
 using SME.CDEP.TesteIntegracao.ServicosFakes;
 using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.Aplicacao.Integracoes.Interfaces;
-using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao.Usuario
 {

--- a/teste/SME.CDEP.TesteIntegracao/Usuarios/Ao_fazer_manutencao_usuario.cs
+++ b/teste/SME.CDEP.TesteIntegracao/Usuarios/Ao_fazer_manutencao_usuario.cs
@@ -5,6 +5,7 @@ using SME.CDEP.TesteIntegracao.Setup;
 using SME.CDEP.Infra.Dominio.Enumerados;
 using SME.CDEP.TesteIntegracao.Constantes;
 using Xunit;
+using SME.CDEP.Dominio.Extensions;
 
 namespace SME.CDEP.TesteIntegracao.Usuario
 {

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoDownloadArquivoTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoDownloadArquivoTestes.cs
@@ -1,0 +1,155 @@
+﻿using Bogus;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.ServicoArmazenamento.Interface;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
+{
+    public class ServicoDownloadArquivoTestes
+    {
+        private readonly Mock<IRepositorioArquivo> repositorioArquivoMock;
+        private readonly Mock<IServicoArmazenamento> servicoArmazenamentoMock;
+        private readonly ServicoDownloadArquivo sut;
+
+        public ServicoDownloadArquivoTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioArquivoMock = mocker.GetMock<IRepositorioArquivo>();
+            servicoArmazenamentoMock = mocker.GetMock<IServicoArmazenamento>();
+
+            sut = mocker.CreateInstance<ServicoDownloadArquivo>();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarServico_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ServicoDownloadArquivo(repositorioArquivoMock.Object, servicoArmazenamentoMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DadoArquivoSemEnderecoNoArmazenamento_QuandoDownload_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var codigoArquivo = Guid.NewGuid();
+            var arquivoMock = GerarArquivoMock(codigoArquivo);
+
+            repositorioArquivoMock
+                .Setup(r => r.ObterPorCodigo(codigoArquivo))
+                .ReturnsAsync(arquivoMock);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(string.Empty);
+
+            // Act
+            Func<Task> acao = async () => await sut.Download(codigoArquivo);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.ARQUIVO_NAO_ENCONTRADO);
+
+            repositorioArquivoMock.Verify(r => r.ObterPorCodigo(codigoArquivo), Times.Once);
+            servicoArmazenamentoMock.Verify(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoArquivoSemEnderecoNoArmazenamento_QuandoDownloadPorTipoAcervo_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var tipoAcervo = TipoAcervo.Fotografico;
+            var arquivoMock = GerarArquivoMock(Guid.NewGuid());
+
+            repositorioArquivoMock
+                .Setup(r => r.ObterArquivoPorNomeTipoArquivo(It.IsAny<string>(), TipoArquivo.Sistema))
+                .ReturnsAsync(arquivoMock);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(string.Empty);
+
+            // Act
+            Func<Task> acao = async () => await sut.DownloadPorTipoAcervo(tipoAcervo);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.ARQUIVO_NAO_ENCONTRADO);
+
+            repositorioArquivoMock.Verify(r => r.ObterArquivoPorNomeTipoArquivo(It.IsAny<string>(), TipoArquivo.Sistema), Times.Once);
+            servicoArmazenamentoMock.Verify(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoUrlInvalidaParaHttpClient_QuandoDownload_EntaoLancaHttpRequestException()
+        {
+            // Arrange
+            var codigoArquivo = Guid.NewGuid();
+            var arquivoMock = GerarArquivoMock(codigoArquivo);
+            var urlInvalidaHttp = "http://localhost-url-invalida-teste-download";
+
+            repositorioArquivoMock
+                .Setup(r => r.ObterPorCodigo(codigoArquivo))
+                .ReturnsAsync(arquivoMock);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(urlInvalidaHttp);
+
+            // Act
+            Func<Task> acao = async () => await sut.Download(codigoArquivo);
+
+            // Assert
+            await acao.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task DadoUrlInvalidaParaWebClient_QuandoGerarMiniatura_EntaoLancaExcecaoDeRede()
+        {
+            // Arrange
+            var codigoArquivo = Guid.NewGuid();
+            var arquivoMock = GerarArquivoMock(codigoArquivo);
+            var urlInvalidaWebClient = "http://localhost-url-invalida-teste-miniatura";
+
+            repositorioArquivoMock
+                .Setup(r => r.ObterPorCodigo(codigoArquivo))
+                .ReturnsAsync(arquivoMock);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(urlInvalidaWebClient);
+
+            // Act
+            Func<Task> acao = async () => await sut.GerarMiniatura(codigoArquivo);
+
+            // Assert
+            await acao.Should().ThrowAsync<System.Net.WebException>();
+
+            repositorioArquivoMock.Verify(r => r.ObterPorCodigo(codigoArquivo), Times.Once);
+            servicoArmazenamentoMock.Verify(s => s.Obter(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static Arquivo GerarArquivoMock(Guid codigoArquivo)
+        {
+            return new Faker<Arquivo>("pt_BR")
+                .RuleFor(a => a.Codigo, codigoArquivo)
+                .RuleFor(a => a.Nome, f => f.System.FileName("jpg"))
+                .RuleFor(a => a.TipoConteudo, "image/jpeg")
+                .RuleFor(a => a.Tipo, f => f.PickRandom<TipoArquivo>())
+                .Generate();
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoGerarMiniaturaTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoGerarMiniaturaTestes.cs
@@ -1,0 +1,175 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Moq.Protected;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.ServicoArmazenamento.Interface;
+using System.Net;
+using System.Text;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
+{
+    public class ServicoGerarMiniaturaTestes
+    {
+        private readonly Mock<IServicoArmazenamento> servicoArmazenamentoMock;
+        private readonly Mock<IRepositorioArquivo> repositorioArquivoMock;
+        private readonly Mock<IHttpClientFactory> httpClientFactoryMock;
+        private readonly ServicoGerarMiniatura sut;
+
+        public ServicoGerarMiniaturaTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoArmazenamentoMock = mocker.GetMock<IServicoArmazenamento>();
+            repositorioArquivoMock = mocker.GetMock<IRepositorioArquivo>();
+            httpClientFactoryMock = mocker.GetMock<IHttpClientFactory>();
+
+            sut = mocker.CreateInstance<ServicoGerarMiniatura>();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarServico_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () =>
+            {
+                _ = new ServicoGerarMiniatura(
+                    servicoArmazenamentoMock.Object,
+                    repositorioArquivoMock.Object,
+                    httpClientFactoryMock.Object);
+            };
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DadoParametrosValidos_QuandoGerarMiniatura_EntaoGeraESalvaMiniaturaComSucesso()
+        {
+            // Arrange
+            var idEsperado = 99L;
+            var nomeArquivoFisico = "imagem_teste.jpg";
+            var nomeMiniatura = "miniatura_teste.jpg";
+            var tipoConteudo = "image/jpeg";
+            var tipoArquivo = TipoArquivo.AcervoFotografico;
+            var urlImagem = "http://fake-storage.com/imagem_teste.jpg";
+
+            var bytesImagemValida = GerarBytesImagemDummyEmMemoria();
+            MockarRespostaHttpClient(HttpStatusCode.OK, bytesImagemValida);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(nomeArquivoFisico, false))
+                .ReturnsAsync(urlImagem);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Armazenar(It.IsAny<string>(), It.IsAny<Stream>(), tipoConteudo))
+                .ReturnsAsync("url_gerada_armazenamento");
+
+            repositorioArquivoMock
+                .Setup(r => r.SalvarAsync(It.IsAny<Arquivo>()))
+                .ReturnsAsync(idEsperado);
+
+            // Act
+            var resultado = await sut.GerarMiniatura(tipoConteudo, nomeArquivoFisico, nomeMiniatura, tipoArquivo);
+
+            // Assert
+            resultado.Should().Be(idEsperado);
+
+            servicoArmazenamentoMock.Verify(s => s.Obter(nomeArquivoFisico, false), Times.Once);
+
+            servicoArmazenamentoMock.Verify(s => s.Armazenar(
+                It.Is<string>(nome => nome.EndsWith(".jpg")),
+                It.IsAny<Stream>(),
+                tipoConteudo), Times.Once);
+
+            repositorioArquivoMock.Verify(r => r.SalvarAsync(It.Is<Arquivo>(a =>
+                a.Nome == nomeMiniatura &&
+                a.TipoConteudo == tipoConteudo &&
+                a.Tipo == tipoArquivo &&
+                a.Codigo != Guid.Empty)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoUrlInacessivelNoArmazenamento_QuandoGerarMiniatura_EntaoLancaHttpRequestException()
+        {
+            // Arrange
+            var nomeArquivoFisico = "imagem_inexistente.jpg";
+            var urlInvalida = "http://fake-storage.com/imagem_inexistente.jpg";
+
+            MockarRespostaHttpClient(HttpStatusCode.NotFound, Array.Empty<byte>());
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(nomeArquivoFisico, false))
+                .ReturnsAsync(urlInvalida);
+
+            // Act
+            Func<Task> acao = async () => await sut.GerarMiniatura("image/jpeg", nomeArquivoFisico, "miniatura", TipoArquivo.AcervoFotografico);
+
+            // Assert
+            await acao.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task DadoConteudoRetornadoNaoSendoImagemValida_QuandoGerarMiniatura_EntaoLancaUnknownImageFormatException()
+        {
+            // Arrange
+            var nomeArquivoFisico = "arquivo_corrompido.jpg";
+            var urlArquivo = "http://fake-storage.com/arquivo_corrompido.jpg";
+
+            var bytesNaoImagem = Encoding.UTF8.GetBytes("Isso não é uma imagem válida, é um texto.");
+
+            MockarRespostaHttpClient(HttpStatusCode.OK, bytesNaoImagem);
+
+            servicoArmazenamentoMock
+                .Setup(s => s.Obter(nomeArquivoFisico, false))
+                .ReturnsAsync(urlArquivo);
+
+            // Act
+            Func<Task> acao = async () => await sut.GerarMiniatura("image/jpeg", nomeArquivoFisico, "min", TipoArquivo.AcervoFotografico);
+
+            // Assert
+            await acao.Should().ThrowAsync<UnknownImageFormatException>();
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void MockarRespostaHttpClient(HttpStatusCode statusCode, byte[] conteudoRetorno)
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new ByteArrayContent(conteudoRetorno)
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+
+            httpClientFactoryMock
+                .Setup(f => f.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+        }
+
+        private static byte[] GerarBytesImagemDummyEmMemoria()
+        {
+            using var img = new Image<Rgba32>(10, 10);
+            using var ms = new MemoryStream();
+
+            img.SaveAsJpeg(ms);
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoMenuTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoMenuTestes.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Infra.Dominio.Enumerados;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
+{
+    public class ServicoMenuTestes
+    {
+        private readonly Mock<IServicoUsuario> servicoUsuarioMock;
+        private readonly ServicoMenu sut;
+
+        public ServicoMenuTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoUsuarioMock = mocker.GetMock<IServicoUsuario>();
+
+            sut = mocker.CreateInstance<ServicoMenu>();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarServico_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ServicoMenu(servicoUsuarioMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DadoServicoUsuarioNulo_QuandoInstanciarServico_EntaoLancaArgumentNullException()
+        {
+            // Arrange
+            Action acao = () => new ServicoMenu(null!);
+
+            // Act & Assert
+            acao.Should().Throw<ArgumentNullException>().WithParameterName("servicoUsuario");
+        }
+
+        [Fact]
+        public async Task DadoUsuarioSemPermissoes_QuandoObterMenu_EntaoRetornaListaVazia()
+        {
+            // Arrange
+            servicoUsuarioMock
+                .Setup(s => s.ObterPermissoes())
+                .Returns([]);
+
+            // Act
+            var resultado = await sut.ObterMenu();
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().BeEmpty();
+            servicoUsuarioMock.Verify(s => s.ObterPermissoes(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoPermissoesInvalidasForaDoEnum_QuandoObterMenu_EntaoFiltraIgnorandoAsInvalidas()
+        {
+            // Arrange
+            var permissaoInvalida = (Permissao)9999;
+
+            var permissoes = new List<Permissao>
+            {
+                permissaoInvalida
+            };
+
+            servicoUsuarioMock
+                .Setup(s => s.ObterPermissoes())
+                .Returns(permissoes);
+
+            // Act
+            var resultado = await sut.ObterMenu();
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().BeEmpty();
+            servicoUsuarioMock.Verify(s => s.ObterPermissoes(), Times.Once);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoNotificacaoEmailTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoNotificacaoEmailTestes.cs
@@ -1,0 +1,93 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
+{
+    public class ServicoNotificacaoEmailTestes
+    {
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ServicoNotificacaoEmail sut;
+
+        public ServicoNotificacaoEmailTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ServicoNotificacaoEmail>();
+        }
+
+        [Fact]
+        public async Task DadoParametrosValidos_QuandoEnviar_EntaoBuscaParametrosETentaConectarLancandoExcecaoDeRede()
+        {
+            // Arrange
+            ConfigurarMocksPadroes();
+            var nomeDestinatario = "Usuário Teste";
+            var emailDestinatario = "teste@teste.com.br";
+            var assunto = "Assunto Teste";
+            var mensagem = "<p>Mensagem Teste</p>";
+
+            // Act
+            Func<Task> acao = async () => await sut.Enviar(nomeDestinatario, emailDestinatario, assunto, mensagem);
+
+            // Assert
+            await acao.Should().ThrowAsync<Exception>();
+
+            repositorioParametroSistemaMock.Verify(r => r.ObterParametroPorTipoEAno(TipoParametroSistema.EmailRemetente, It.IsAny<int>()), Times.Once);
+            repositorioParametroSistemaMock.Verify(r => r.ObterParametroPorTipoEAno(TipoParametroSistema.EnderecoSMTP, It.IsAny<int>()), Times.Once);
+            repositorioParametroSistemaMock.Verify(r => r.ObterParametroPorTipoEAno(TipoParametroSistema.UsuarioRemetenteEmail, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoParametroPortaInvalido_QuandoEnviar_EntaoLancaFormatException()
+        {
+            // Arrange
+            ConfigurarMocksPadroes();
+            MockarParametro(TipoParametroSistema.PortaEnvioEmail, "PORTA_INVALIDA");
+
+            // Act
+            Func<Task> acao = async () => await sut.Enviar("Destinatario", "dest@teste.com", "Assunto", "Mensagem");
+
+            // Assert
+            await acao.Should().ThrowAsync<FormatException>();
+        }
+
+        [Fact]
+        public async Task DadoParametroUsarTlsInvalido_QuandoEnviar_EntaoLancaFormatException()
+        {
+            // Arrange
+            ConfigurarMocksPadroes();
+            MockarParametro(TipoParametroSistema.UsarTLSEmail, "VALOR_BOOLEANO_INVALIDO");
+
+            // Act
+            Func<Task> acao = async () => await sut.Enviar("Destinatario", "dest@teste.com", "Assunto", "Mensagem");
+
+            // Assert
+            await acao.Should().ThrowAsync<FormatException>();
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroes()
+        {
+            MockarParametro(TipoParametroSistema.EmailRemetente, "remetente@sistema.com.br");
+            MockarParametro(TipoParametroSistema.NomeRemetenteEmail, "Sistema CDEP");
+            MockarParametro(TipoParametroSistema.EnderecoSMTP, "smtp.servidor-ficticio.local");
+            MockarParametro(TipoParametroSistema.UsuarioRemetenteEmail, "usuario_smtp");
+            MockarParametro(TipoParametroSistema.SenhaRemetenteEmail, "senha_super_secreta");
+            MockarParametro(TipoParametroSistema.UsarTLSEmail, "true");
+            MockarParametro(TipoParametroSistema.PortaEnvioEmail, "587");
+        }
+
+        private void MockarParametro(TipoParametroSistema tipo, string valorMockado)
+        {
+            repositorioParametroSistemaMock
+                .Setup(r => r.ObterParametroPorTipoEAno(tipo, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = valorMockado });
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoArteGraficaUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoArteGraficaUseCaseTestes.cs
@@ -1,0 +1,373 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class ExecutarImportacaoArquivoAcervoArteGraficaUseCaseTestes
+    {
+        private readonly Mock<IRepositorioImportacaoArquivo> repositorioImportacaoArquivoMock;
+        private readonly Mock<IServicoMaterial> servicoMaterialMock;
+        private readonly Mock<IServicoEditora> servicoEditoraMock;
+        private readonly Mock<IServicoSerieColecao> servicoSerieColecaoMock;
+        private readonly Mock<IServicoIdioma> servicoIdiomaMock;
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly Mock<IServicoCreditoAutor> servicoCreditoAutorMock;
+        private readonly Mock<IServicoConservacao> servicoConservacaoMock;
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly Mock<IServicoCromia> servicoCromiaMock;
+        private readonly Mock<IServicoSuporte> servicoSuporteMock;
+        private readonly Mock<IServicoFormato> servicoFormatoMock;
+        private readonly Mock<IServicoAcervoArteGrafica> servicoAcervoArteGraficaMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ExecutarImportacaoArquivoAcervoArteGraficaUseCase sut;
+
+        public ExecutarImportacaoArquivoAcervoArteGraficaUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioImportacaoArquivoMock = mocker.GetMock<IRepositorioImportacaoArquivo>();
+            servicoMaterialMock = mocker.GetMock<IServicoMaterial>();
+            servicoEditoraMock = mocker.GetMock<IServicoEditora>();
+            servicoSerieColecaoMock = mocker.GetMock<IServicoSerieColecao>();
+            servicoIdiomaMock = mocker.GetMock<IServicoIdioma>();
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+            servicoCreditoAutorMock = mocker.GetMock<IServicoCreditoAutor>();
+            servicoConservacaoMock = mocker.GetMock<IServicoConservacao>();
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+            servicoCromiaMock = mocker.GetMock<IServicoCromia>();
+            servicoSuporteMock = mocker.GetMock<IServicoSuporte>();
+            servicoFormatoMock = mocker.GetMock<IServicoFormato>();
+            servicoAcervoArteGraficaMock = mocker.GetMock<IServicoAcervoArteGrafica>();
+            mapperMock = mocker.GetMock<IMapper>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ExecutarImportacaoArquivoAcervoArteGraficaUseCase>();
+
+            ConfigurarMocksPadroesDominios();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarUseCase_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoArteGraficaUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                servicoAcervoArteGraficaMock.Object, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DadoServicoAcervoArteGraficaNulo_QuandoInstanciarUseCase_EntaoLancaArgumentNullException()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoArteGraficaUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                null!, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().Throw<ArgumentNullException>().WithParameterName("servicoAcervoArteGrafica");
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "NaoNumerico" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoNaoLocalizada_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var idImportacao = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync((ImportacaoArquivo)null!);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComSucesso_QuandoExecutar_EntaoAtualizaStatusParaSucesso()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { ObterLinhaArteGraficaDTOPreenchida(1) };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.ArtesGraficas
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Sucesso)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComErro_QuandoExecutar_EntaoAtualizaStatusParaErros()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhaComErro = ObterLinhaArteGraficaDTOPreenchida(1);
+
+            // Forçamos um erro de negócio atribuindo um valor que não existe nos mocks de domínio
+            linhaComErro.Cromia.Conteudo = "CROMIA_INEXISTENTE";
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { linhaComErro };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.ArtesGraficas
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Erros)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaCarregarDominios_QuandoExecutado_EntaoCarregaDependenciasArteGrafica()
+        {
+            // Arrange (Mocks já configurados no construtor)
+
+            // Act
+            await sut.CarregarDominiosArteGrafica();
+
+            // Assert
+            servicoCreditoAutorMock.Verify(s => s.ObterTodos(), Times.Once);
+            servicoSuporteMock.Verify(s => s.ObterTodos(), Times.Once);
+            repositorioParametroSistemaMock.Verify(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.LimiteAcervosImportadosViaPanilha, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLinhasSemErro_QuandoPersistenciaAcervo_EntaoInsereAcervoEDefineComoSucesso()
+        {
+            // Arrange
+            await sut.CarregarDominiosArteGrafica();
+
+            var linhaValida = ObterLinhaArteGraficaDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { linhaValida };
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoArteGraficaCadastroDTO>()))
+                .ReturnsAsync(1L);
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            servicoAcervoArteGraficaMock.Verify(s => s.Inserir(It.IsAny<AcervoArteGraficaCadastroDTO>()), Times.Once);
+            linhaValida.PossuiErros.Should().BeFalse();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Sucesso);
+        }
+
+        [Fact]
+        public async Task DadoErroNaInsercaoAcervo_QuandoPersistenciaAcervo_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosArteGrafica();
+
+            var linhaValida = ObterLinhaArteGraficaDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { linhaValida };
+            var mensagemErro = "Erro ao persistir banco";
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoArteGraficaCadastroDTO>()))
+                .ThrowsAsync(new Exception(mensagemErro));
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            linhaValida.PossuiErros.Should().BeTrue();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaValida.Mensagem.Should().Be(mensagemErro);
+        }
+
+        [Fact]
+        public void DadoExcecaoNaoTratadaNaValidacao_QuandoValidarPreenchimento_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            var linhaComFalhaGrave = new AcervoArteGraficaLinhaDTO
+            {
+                NumeroLinha = 1,
+                // Provocará NullReferenceException durante a validação por não estar instanciado
+                Titulo = null!
+            };
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { linhaComFalhaGrave };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            // O SUT captura internamente a exception e atualiza o objeto DTO
+            linhaComFalhaGrave.PossuiErros.Should().BeTrue();
+            linhaComFalhaGrave.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaComFalhaGrave.Mensagem.Should().Contain("Ocorreu uma falha inesperada na linha");
+        }
+
+        [Fact]
+        public void DadoLinhaComLimitesExcedidos_QuandoValidarPreenchimento_EntaoDefinePossuiErrosComoTrue()
+        {
+            // Arrange
+            var linhaInvalida = ObterLinhaArteGraficaDTOPreenchida(1);
+            linhaInvalida.Titulo.Conteudo = new string('A', 501); // Excede o limite de 500
+
+            var linhas = new List<AcervoArteGraficaLinhaDTO> { linhaInvalida };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaInvalida.Titulo.PossuiErro.Should().BeTrue();
+            linhaInvalida.PossuiErros.Should().BeTrue();
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroesDominios()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(It.IsAny<TipoParametroSistema>(), It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "100" });
+
+            var listaCredito = new List<IdNomeTipoExcluidoAuditavelDTO> { new IdNomeTipoExcluidoAuditavelDTO { Id = 1L, Nome = "Autor Grafico", Tipo = (int)TipoCreditoAutoria.Credito } };
+            servicoCreditoAutorMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCredito);
+
+            var listaSuportes = new List<IdNomeTipoExcluidoDTO> { new IdNomeTipoExcluidoDTO { Id = 2L, Nome = "Tela", Tipo = (int)TipoSuporte.IMAGEM } };
+            servicoSuporteMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaSuportes);
+
+            var listaConservacao = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 3L, Nome = "Bom" } };
+            servicoConservacaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaConservacao);
+
+            var listaCromia = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 4L, Nome = "Monocromático" } };
+            servicoCromiaMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCromia);
+
+            // Mockando Retornos genéricos vazios com seus tipos concretos para o restante
+            servicoIdiomaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoMaterialMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoAcessoDocumentoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoEditoraMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoSerieColecaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoAssuntoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoFormatoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+
+            // Mapeador simulando o comportamento do AutoMapper
+            mapperMock.Setup(m => m.Map<IdNomeDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeDTO { Id = s.Id, Nome = s.Nome };
+            });
+
+            mapperMock.Setup(m => m.Map<IdNomeTipoDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeTipoDTO { Id = s.Id, Nome = s.Nome, Tipo = s.Tipo };
+            });
+        }
+
+        private AcervoArteGraficaLinhaDTO ObterLinhaArteGraficaDTOPreenchida(int numeroLinha)
+        {
+            return new AcervoArteGraficaLinhaDTO
+            {
+                NumeroLinha = numeroLinha,
+                PossuiErros = false,
+                Titulo = new LinhaConteudoAjustarDTO { Conteudo = "Obra Arte", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Codigo = new LinhaConteudoAjustarDTO { Conteudo = "COD-AG1", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Credito = new LinhaConteudoAjustarDTO { Conteudo = "Autor Grafico", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Localizacao = new LinhaConteudoAjustarDTO { Conteudo = "Sala 1", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                Procedencia = new LinhaConteudoAjustarDTO { Conteudo = "Doação", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Ano = new LinhaConteudoAjustarDTO { Conteudo = "2020", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 7 },
+                CopiaDigital = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 3 },
+                PermiteUsoImagem = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 3 },
+                EstadoConservacao = new LinhaConteudoAjustarDTO { Conteudo = "Bom", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Cromia = new LinhaConteudoAjustarDTO { Conteudo = "Monocromático", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Largura = new LinhaConteudoAjustarDTO { Conteudo = "15.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Altura = new LinhaConteudoAjustarDTO { Conteudo = "20.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Diametro = new LinhaConteudoAjustarDTO { Conteudo = "0", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Tecnica = new LinhaConteudoAjustarDTO { Conteudo = "Aquarela", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                Suporte = new LinhaConteudoAjustarDTO { Conteudo = "Tela", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Quantidade = new LinhaConteudoAjustarDTO { Conteudo = "1", FormatoTipoDeCampo = Constantes.FORMATO_INTEIRO },
+                Descricao = new LinhaConteudoAjustarDTO { Conteudo = "Descrição da obra", FormatoTipoDeCampo = Constantes.FORMATO_STRING }
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoAudiovisualUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoAudiovisualUseCaseTestes.cs
@@ -1,0 +1,367 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class ExecutarImportacaoArquivoAcervoAudiovisualUseCaseTestes
+    {
+        private readonly Mock<IRepositorioImportacaoArquivo> repositorioImportacaoArquivoMock;
+        private readonly Mock<IServicoMaterial> servicoMaterialMock;
+        private readonly Mock<IServicoEditora> servicoEditoraMock;
+        private readonly Mock<IServicoSerieColecao> servicoSerieColecaoMock;
+        private readonly Mock<IServicoIdioma> servicoIdiomaMock;
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly Mock<IServicoCreditoAutor> servicoCreditoAutorMock;
+        private readonly Mock<IServicoConservacao> servicoConservacaoMock;
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly Mock<IServicoCromia> servicoCromiaMock;
+        private readonly Mock<IServicoSuporte> servicoSuporteMock;
+        private readonly Mock<IServicoFormato> servicoFormatoMock;
+        private readonly Mock<IServicoAcervoAudiovisual> servicoAcervoAudiovisualMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ExecutarImportacaoArquivoAcervoAudiovisualUseCase sut;
+
+        public ExecutarImportacaoArquivoAcervoAudiovisualUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioImportacaoArquivoMock = mocker.GetMock<IRepositorioImportacaoArquivo>();
+            servicoMaterialMock = mocker.GetMock<IServicoMaterial>();
+            servicoEditoraMock = mocker.GetMock<IServicoEditora>();
+            servicoSerieColecaoMock = mocker.GetMock<IServicoSerieColecao>();
+            servicoIdiomaMock = mocker.GetMock<IServicoIdioma>();
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+            servicoCreditoAutorMock = mocker.GetMock<IServicoCreditoAutor>();
+            servicoConservacaoMock = mocker.GetMock<IServicoConservacao>();
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+            servicoCromiaMock = mocker.GetMock<IServicoCromia>();
+            servicoSuporteMock = mocker.GetMock<IServicoSuporte>();
+            servicoFormatoMock = mocker.GetMock<IServicoFormato>();
+            servicoAcervoAudiovisualMock = mocker.GetMock<IServicoAcervoAudiovisual>();
+            mapperMock = mocker.GetMock<IMapper>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ExecutarImportacaoArquivoAcervoAudiovisualUseCase>();
+
+            ConfigurarMocksPadroesDominios();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarUseCase_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoAudiovisualUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                servicoAcervoAudiovisualMock.Object, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DadoServicoAcervoAudiovisualNulo_QuandoInstanciarUseCase_EntaoLancaArgumentNullException()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoAudiovisualUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                null!, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().Throw<ArgumentNullException>().WithParameterName("servicoAcervoAudiovisual");
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "INVALIDO_NAO_NUMERICO" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoNaoLocalizada_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var idImportacao = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync((ImportacaoArquivo)null!);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComSucesso_QuandoExecutar_EntaoAtualizaStatusParaSucesso()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { ObterLinhaAudiovisualDTOPreenchida(1) };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.Audiovisual
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Sucesso)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComErro_QuandoExecutar_EntaoAtualizaStatusParaErros()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhaComErro = ObterLinhaAudiovisualDTOPreenchida(1);
+
+            linhaComErro.Suporte.Conteudo = "SUPORTE_INEXISTENTE";
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { linhaComErro };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.Audiovisual
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Erros)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaCarregarDominios_QuandoExecutado_EntaoCarregaDependenciasAudiovisuais()
+        {
+            // Act
+            await sut.CarregarDominiosAudiovisuais();
+
+            // Assert
+            servicoCreditoAutorMock.Verify(s => s.ObterTodos(), Times.Once);
+            servicoSuporteMock.Verify(s => s.ObterTodos(), Times.Once);
+            repositorioParametroSistemaMock.Verify(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.LimiteAcervosImportadosViaPanilha, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLinhasSemErro_QuandoPersistenciaAcervo_EntaoInsereAcervoEDefineComoSucesso()
+        {
+            // Arrange
+            await sut.CarregarDominiosAudiovisuais();
+
+            var linhaValida = ObterLinhaAudiovisualDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { linhaValida };
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoAudiovisualCadastroDTO>()))
+                .ReturnsAsync(1L);
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            servicoAcervoAudiovisualMock.Verify(s => s.Inserir(It.IsAny<AcervoAudiovisualCadastroDTO>()), Times.Once);
+            linhaValida.PossuiErros.Should().BeFalse();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Sucesso);
+        }
+
+        [Fact]
+        public async Task DadoErroNaInsercaoAcervo_QuandoPersistenciaAcervo_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosAudiovisuais();
+
+            var linhaValida = ObterLinhaAudiovisualDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { linhaValida };
+            var mensagemErro = "Falha ao gravar registro de acervo audiovisual";
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoAudiovisualCadastroDTO>()))
+                .ThrowsAsync(new Exception(mensagemErro));
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            linhaValida.PossuiErros.Should().BeTrue();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaValida.Mensagem.Should().Be(mensagemErro);
+        }
+
+        [Fact]
+        public async Task DadoLinhaComLimitesExcedidos_QuandoValidarPreenchimento_EntaoDefinePossuiErrosComoTrue()
+        {
+            // Arrange
+            await sut.CarregarDominiosAudiovisuais();
+
+            var linhaInvalida = ObterLinhaAudiovisualDTOPreenchida(1);
+            linhaInvalida.Titulo.Conteudo = new string('A', 501); // Excede o limite provável de 500
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { linhaInvalida };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaInvalida.Titulo.PossuiErro.Should().BeTrue();
+            linhaInvalida.PossuiErros.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DadoExcecaoNaoTratadaNaValidacao_QuandoValidarPreenchimento_EntaoDefineLinhaComoErroOuLancaExcecao()
+        {
+            // Arrange
+            var linhaComFalhaGrave = new AcervoAudiovisualLinhaDTO
+            {
+                NumeroLinha = 1,
+                Titulo = null!
+            };
+
+            var linhas = new List<AcervoAudiovisualLinhaDTO> { linhaComFalhaGrave };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaComFalhaGrave.PossuiErros.Should().BeTrue();
+            linhaComFalhaGrave.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaComFalhaGrave.Mensagem.Should().Contain("Ocorreu uma falha inesperada na linha");
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroesDominios()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(It.IsAny<TipoParametroSistema>(), It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "100" });
+
+            var listaCredito = new List<IdNomeTipoExcluidoAuditavelDTO> { new IdNomeTipoExcluidoAuditavelDTO { Id = 1L, Nome = "Autor Audiovisual", Tipo = (int)TipoCreditoAutoria.Credito } };
+            servicoCreditoAutorMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCredito);
+
+            var listaSuportes = new List<IdNomeTipoExcluidoDTO> { new IdNomeTipoExcluidoDTO { Id = 2L, Nome = "Digital", Tipo = (int)TipoSuporte.VIDEO } };
+            servicoSuporteMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaSuportes);
+
+            var listaConservacao = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 3L, Nome = "Bom" } };
+            servicoConservacaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaConservacao);
+
+            var listaCromia = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 4L, Nome = "Colorido" } };
+            servicoCromiaMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCromia);
+
+            servicoIdiomaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoMaterialMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoAcessoDocumentoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoEditoraMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoSerieColecaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoAssuntoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoFormatoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+
+            mapperMock.Setup(m => m.Map<IdNomeDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeDTO { Id = s.Id, Nome = s.Nome };
+            });
+
+            mapperMock.Setup(m => m.Map<IdNomeTipoDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeTipoDTO { Id = s.Id, Nome = s.Nome, Tipo = s.Tipo };
+            });
+        }
+
+        private AcervoAudiovisualLinhaDTO ObterLinhaAudiovisualDTOPreenchida(int numeroLinha)
+        {
+            return new AcervoAudiovisualLinhaDTO
+            {
+                NumeroLinha = numeroLinha,
+                PossuiErros = false,
+                Titulo = new LinhaConteudoAjustarDTO { Conteudo = "Obra Audiovisual", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Codigo = new LinhaConteudoAjustarDTO { Conteudo = "COD-AV1", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Credito = new LinhaConteudoAjustarDTO { Conteudo = "Autor Audiovisual", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Localizacao = new LinhaConteudoAjustarDTO { Conteudo = "Sala 2", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                Procedencia = new LinhaConteudoAjustarDTO { Conteudo = "Doação", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Ano = new LinhaConteudoAjustarDTO { Conteudo = "2021", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 7 },
+                Copia = new LinhaConteudoAjustarDTO { Conteudo = "Cópia 1", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                PermiteUsoImagem = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 3 },
+                EstadoConservacao = new LinhaConteudoAjustarDTO { Conteudo = "Bom", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Descricao = new LinhaConteudoAjustarDTO { Conteudo = "Descrição do vídeo", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Suporte = new LinhaConteudoAjustarDTO { Conteudo = "Digital", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Duracao = new LinhaConteudoAjustarDTO { Conteudo = "01:30:00", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Cromia = new LinhaConteudoAjustarDTO { Conteudo = "Colorido", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                TamanhoArquivo = new LinhaConteudoAjustarDTO { Conteudo = "2GB", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Acessibilidade = new LinhaConteudoAjustarDTO { Conteudo = "Libras", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                Disponibilizacao = new LinhaConteudoAjustarDTO { Conteudo = "Internet", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 }
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoDocumentalUseCaseTestes.cs
@@ -1,0 +1,335 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class ExecutarImportacaoArquivoAcervoDocumentalUseCaseTestes
+    {
+        private readonly Mock<IRepositorioImportacaoArquivo> repositorioImportacaoArquivoMock;
+        private readonly Mock<IServicoMaterial> servicoMaterialMock;
+        private readonly Mock<IServicoEditora> servicoEditoraMock;
+        private readonly Mock<IServicoSerieColecao> servicoSerieColecaoMock;
+        private readonly Mock<IServicoIdioma> servicoIdiomaMock;
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly Mock<IServicoCreditoAutor> servicoCreditoAutorMock;
+        private readonly Mock<IServicoConservacao> servicoConservacaoMock;
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly Mock<IServicoCromia> servicoCromiaMock;
+        private readonly Mock<IServicoSuporte> servicoSuporteMock;
+        private readonly Mock<IServicoFormato> servicoFormatoMock;
+        private readonly Mock<IServicoAcervoDocumental> servicoAcervoDocumentalMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ExecutarImportacaoArquivoAcervoDocumentalUseCase sut;
+
+        public ExecutarImportacaoArquivoAcervoDocumentalUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioImportacaoArquivoMock = mocker.GetMock<IRepositorioImportacaoArquivo>();
+            servicoMaterialMock = mocker.GetMock<IServicoMaterial>();
+            servicoEditoraMock = mocker.GetMock<IServicoEditora>();
+            servicoSerieColecaoMock = mocker.GetMock<IServicoSerieColecao>();
+            servicoIdiomaMock = mocker.GetMock<IServicoIdioma>();
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+            servicoCreditoAutorMock = mocker.GetMock<IServicoCreditoAutor>();
+            servicoConservacaoMock = mocker.GetMock<IServicoConservacao>();
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+            servicoCromiaMock = mocker.GetMock<IServicoCromia>();
+            servicoSuporteMock = mocker.GetMock<IServicoSuporte>();
+            servicoFormatoMock = mocker.GetMock<IServicoFormato>();
+            servicoAcervoDocumentalMock = mocker.GetMock<IServicoAcervoDocumental>();
+            mapperMock = mocker.GetMock<IMapper>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ExecutarImportacaoArquivoAcervoDocumentalUseCase>();
+
+            ConfigurarMocksPadroesDominios();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarUseCase_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoDocumentalUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                servicoAcervoDocumentalMock.Object, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "ID_INVALIDO" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoNaoLocalizada_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var idImportacao = 99L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync((ImportacaoArquivo)null!);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComSucesso_QuandoExecutar_EntaoAtualizaStatusParaSucesso()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhas = new List<AcervoDocumentalLinhaDTO> { ObterLinhaDocumentalDTOPreenchida(1) };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.DocumentacaoTextual
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Sucesso)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaCarregarDominios_QuandoExecutado_EntaoCarregaDependenciasDocumentais()
+        {
+            // Act
+            await sut.CarregarDominiosDocumentais();
+
+            // Assert
+            servicoMaterialMock.Verify(s => s.ObterTodos(), Times.Once);
+            servicoCreditoAutorMock.Verify(s => s.ObterTodos(), Times.Once);
+            repositorioParametroSistemaMock.Verify(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.LimiteAcervosImportadosViaPanilha, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLinhasSemErro_QuandoPersistenciaAcervo_EntaoInsereAcervoEDefineComoSucesso()
+        {
+            // Arrange
+            await sut.CarregarDominiosDocumentais(); // Carrega os domínios para a validação dos Ids
+
+            var linhaValida = ObterLinhaDocumentalDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoDocumentalLinhaDTO> { linhaValida };
+
+            servicoAcervoDocumentalMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoDocumentalCadastroDTO>()))
+                .ReturnsAsync(1L);
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            servicoAcervoDocumentalMock.Verify(s => s.Inserir(It.IsAny<AcervoDocumentalCadastroDTO>()), Times.Once);
+            linhaValida.PossuiErros.Should().BeFalse();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Sucesso);
+        }
+
+        [Fact]
+        public async Task DadoErroNaInsercaoAcervo_QuandoPersistenciaAcervo_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosDocumentais(); // Carrega os domínios para evitar a exceção de domínio não encontrado
+
+            var linhaValida = ObterLinhaDocumentalDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoDocumentalLinhaDTO> { linhaValida };
+            var mensagemErroBanco = "Erro de banco de dados";
+
+            servicoAcervoDocumentalMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoDocumentalCadastroDTO>()))
+                .ThrowsAsync(new Exception(mensagemErroBanco));
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            linhaValida.PossuiErros.Should().BeTrue();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaValida.Mensagem.Should().Be(mensagemErroBanco);
+        }
+
+        [Fact]
+        public async Task DadoLinhasComCodigosVazios_QuandoValidarPreenchimento_EntaoDefineErroNosDoisCodigos()
+        {
+            // Arrange
+            await sut.CarregarDominiosDocumentais();
+
+            var linhaInvalida = ObterLinhaDocumentalDTOPreenchida(1);
+            linhaInvalida.Codigo.Conteudo = string.Empty;
+            linhaInvalida.CodigoNovo.Conteudo = string.Empty;
+
+            var linhas = new List<AcervoDocumentalLinhaDTO> { linhaInvalida };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaInvalida.Codigo.PossuiErro.Should().BeTrue();
+            linhaInvalida.Codigo.Mensagem.Should().Contain(Constantes.CODIGO_ANTIGO);
+
+            linhaInvalida.CodigoNovo.PossuiErro.Should().BeTrue();
+            linhaInvalida.CodigoNovo.Mensagem.Should().Contain(Constantes.CODIGO_NOVO);
+
+            linhaInvalida.PossuiErros.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task DadoExcecaoNaoTratadaNaValidacao_QuandoValidarPreenchimento_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosDocumentais();
+
+            var linhaComFalhaGrave = new AcervoDocumentalLinhaDTO
+            {
+                NumeroLinha = 1,
+                Titulo = null! // Forçará NullReferenceException durante a validação do Titulo
+            };
+
+            var linhas = new List<AcervoDocumentalLinhaDTO> { linhaComFalhaGrave };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaComFalhaGrave.PossuiErros.Should().BeTrue();
+            linhaComFalhaGrave.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaComFalhaGrave.Mensagem.Should().Contain("Ocorreu uma falha inesperada na linha '1'");
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroesDominios()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(It.IsAny<TipoParametroSistema>(), It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "100" });
+
+            // Instanciando os tipos corretos esperados pelas interfaces para evitar erro de Dynamic Dispatch
+            var listaIdioma = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 1L, Nome = "Português" } };
+            servicoIdiomaMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaIdioma);
+
+            var listaMaterial = new List<IdNomeTipoExcluidoDTO> { new IdNomeTipoExcluidoDTO { Id = 2L, Nome = "Papel", Tipo = (int)TipoMaterial.DOCUMENTAL } };
+            servicoMaterialMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaMaterial);
+
+            var listaCredito = new List<IdNomeTipoExcluidoAuditavelDTO> { new IdNomeTipoExcluidoAuditavelDTO { Id = 3L, Nome = "Autor Teste", Tipo = (int)TipoCreditoAutoria.Autoria } };
+            servicoCreditoAutorMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCredito);
+
+            var listaAcesso = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 4L, Nome = "Público" } };
+            servicoAcessoDocumentoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaAcesso);
+
+            var listaConservacao = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 5L, Nome = "Bom" } };
+            servicoConservacaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaConservacao);
+
+            // Mockando Retornos genéricos vazios com seus tipos concretos
+            servicoSuporteMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoCromiaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoEditoraMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoSerieColecaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoAssuntoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoFormatoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+
+            // Mapeador simulando o comportamento do AutoMapper
+            mapperMock.Setup(m => m.Map<IdNomeDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeDTO { Id = s.Id, Nome = s.Nome };
+            });
+
+            mapperMock.Setup(m => m.Map<IdNomeTipoDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeTipoDTO { Id = s.Id, Nome = s.Nome, Tipo = s.Tipo };
+            });
+        }
+
+        private AcervoDocumentalLinhaDTO ObterLinhaDocumentalDTOPreenchida(int numeroLinha)
+        {
+            return new AcervoDocumentalLinhaDTO
+            {
+                NumeroLinha = numeroLinha,
+                PossuiErros = false,
+                Titulo = new LinhaConteudoAjustarDTO { Conteudo = "Documento Histórico", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Codigo = new LinhaConteudoAjustarDTO { Conteudo = "COD-123", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                CodigoNovo = new LinhaConteudoAjustarDTO { Conteudo = "NCOD-123", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Material = new LinhaConteudoAjustarDTO { Conteudo = "Papel", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Idioma = new LinhaConteudoAjustarDTO { Conteudo = "Português", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Autor = new LinhaConteudoAjustarDTO { Conteudo = "Autor Teste", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Ano = new LinhaConteudoAjustarDTO { Conteudo = "2023", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                NumeroPaginas = new LinhaConteudoAjustarDTO { Conteudo = "100", FormatoTipoDeCampo = Constantes.FORMATO_INTEIRO },
+                Volume = new LinhaConteudoAjustarDTO { Conteudo = "1", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Descricao = new LinhaConteudoAjustarDTO { Conteudo = "Descricao", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                TipoAnexo = new LinhaConteudoAjustarDTO { Conteudo = "Anexo", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Altura = new LinhaConteudoAjustarDTO { Conteudo = "29,7", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Largura = new LinhaConteudoAjustarDTO { Conteudo = "21,0", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                TamanhoArquivo = new LinhaConteudoAjustarDTO { Conteudo = "1MB", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                AcessoDocumento = new LinhaConteudoAjustarDTO { Conteudo = "Público", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                Localizacao = new LinhaConteudoAjustarDTO { Conteudo = "Prateleira A", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                CopiaDigital = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING },
+                EstadoConservacao = new LinhaConteudoAjustarDTO { Conteudo = "Bom", FormatoTipoDeCampo = Constantes.FORMATO_STRING }
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoFotograficoUseCaseTestes.cs
@@ -1,0 +1,332 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class ExecutarImportacaoArquivoAcervoFotograficoUseCaseTestes
+    {
+        private readonly Mock<IRepositorioImportacaoArquivo> repositorioImportacaoArquivoMock;
+        private readonly Mock<IServicoMaterial> servicoMaterialMock;
+        private readonly Mock<IServicoEditora> servicoEditoraMock;
+        private readonly Mock<IServicoSerieColecao> servicoSerieColecaoMock;
+        private readonly Mock<IServicoIdioma> servicoIdiomaMock;
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly Mock<IServicoCreditoAutor> servicoCreditoAutorMock;
+        private readonly Mock<IServicoConservacao> servicoConservacaoMock;
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly Mock<IServicoCromia> servicoCromiaMock;
+        private readonly Mock<IServicoSuporte> servicoSuporteMock;
+        private readonly Mock<IServicoFormato> servicoFormatoMock;
+        private readonly Mock<IServicoAcervoFotografico> servicoAcervoFotograficoMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ExecutarImportacaoArquivoAcervoFotograficoUseCase sut;
+
+        public ExecutarImportacaoArquivoAcervoFotograficoUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioImportacaoArquivoMock = mocker.GetMock<IRepositorioImportacaoArquivo>();
+            servicoMaterialMock = mocker.GetMock<IServicoMaterial>();
+            servicoEditoraMock = mocker.GetMock<IServicoEditora>();
+            servicoSerieColecaoMock = mocker.GetMock<IServicoSerieColecao>();
+            servicoIdiomaMock = mocker.GetMock<IServicoIdioma>();
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+            servicoCreditoAutorMock = mocker.GetMock<IServicoCreditoAutor>();
+            servicoConservacaoMock = mocker.GetMock<IServicoConservacao>();
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+            servicoCromiaMock = mocker.GetMock<IServicoCromia>();
+            servicoSuporteMock = mocker.GetMock<IServicoSuporte>();
+            servicoFormatoMock = mocker.GetMock<IServicoFormato>();
+            servicoAcervoFotograficoMock = mocker.GetMock<IServicoAcervoFotografico>();
+            mapperMock = mocker.GetMock<IMapper>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ExecutarImportacaoArquivoAcervoFotograficoUseCase>();
+
+            ConfigurarMocksPadroesDominios();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarUseCase_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoFotograficoUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                servicoAcervoFotograficoMock.Object, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "INVALIDO" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoNaoLocalizada_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var idImportacao = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync((ImportacaoArquivo)null!);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComSucesso_QuandoExecutar_EntaoAtualizaStatusParaSucesso()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhas = new List<AcervoFotograficoLinhaDTO> { ObterLinhaFotograficaDTOPreenchida(1) };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.Fotografico
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Sucesso)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaCarregarDominios_QuandoExecutado_EntaoCarregaDependenciasFotograficas()
+        {
+            // Act
+            await sut.CarregarDominiosFotograficos();
+
+            // Assert
+            servicoCreditoAutorMock.Verify(s => s.ObterTodos(), Times.Once);
+            servicoFormatoMock.Verify(s => s.ObterTodos(), Times.Once);
+            servicoSuporteMock.Verify(s => s.ObterTodos(), Times.Once);
+            repositorioParametroSistemaMock.Verify(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.LimiteAcervosImportadosViaPanilha, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLinhasSemErro_QuandoPersistenciaAcervo_EntaoInsereAcervoEDefineComoSucesso()
+        {
+            // Arrange
+            await sut.CarregarDominiosFotograficos();
+
+            var linhaValida = ObterLinhaFotograficaDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoFotograficoLinhaDTO> { linhaValida };
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoFotograficoCadastroDTO>()))
+                .ReturnsAsync(1L);
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            servicoAcervoFotograficoMock.Verify(s => s.Inserir(It.IsAny<AcervoFotograficoCadastroDTO>()), Times.Once);
+            linhaValida.PossuiErros.Should().BeFalse();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Sucesso);
+        }
+
+        [Fact]
+        public async Task DadoErroNaInsercaoAcervo_QuandoPersistenciaAcervo_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosFotograficos();
+
+            var linhaValida = ObterLinhaFotograficaDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoFotograficoLinhaDTO> { linhaValida };
+            var mensagemErro = "Erro ao persistir imagem";
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoFotograficoCadastroDTO>()))
+                .ThrowsAsync(new Exception(mensagemErro));
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            linhaValida.PossuiErros.Should().BeTrue();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaValida.Mensagem.Should().Be(mensagemErro);
+        }
+
+        [Fact]
+        public async Task DadoLinhaInvalidaComLimitesExcedidos_QuandoValidarPreenchimento_EntaoDefinePossuiErrosComoTrue()
+        {
+            // Arrange
+            await sut.CarregarDominiosFotograficos();
+
+            var linhaInvalida = ObterLinhaFotograficaDTOPreenchida(1);
+            linhaInvalida.Titulo.Conteudo = new string('A', 501); // Excede o limite de 500 caracteres
+
+            var linhas = new List<AcervoFotograficoLinhaDTO> { linhaInvalida };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaInvalida.Titulo.PossuiErro.Should().BeTrue();
+            linhaInvalida.Titulo.Mensagem.Should().Contain(Constantes.TITULO);
+            linhaInvalida.PossuiErros.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task DadoExcecaoNaoTratadaNaValidacao_QuandoValidarPreenchimento_EntaoDefineLinhaComoErroOuLancaExcecao()
+        {
+            // Arrange
+            await sut.CarregarDominiosFotograficos();
+
+            var linhaComFalhaGrave = new AcervoFotograficoLinhaDTO
+            {
+                NumeroLinha = 1,
+                Titulo = null! // NullReferenceException forcado
+            };
+
+            var linhas = new List<AcervoFotograficoLinhaDTO> { linhaComFalhaGrave };
+
+            // Act
+            Action acao = () => sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            // Se o Catch conseguir capturar, e usar o string.Format com 1 parametro p/ msg de 2. 
+            // Ele lançará um FormatException dentro do catch do SUT.
+            acao.Should().Throw<Exception>();
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroesDominios()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(It.IsAny<TipoParametroSistema>(), It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "100" });
+
+            // Instanciando os tipos corretos esperados pelas interfaces para evitar erro de Dynamic Dispatch
+            var listaCredito = new List<IdNomeTipoExcluidoAuditavelDTO> { new IdNomeTipoExcluidoAuditavelDTO { Id = 1L, Nome = "Autor Foto", Tipo = (int)TipoCreditoAutoria.Credito } };
+            servicoCreditoAutorMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCredito);
+
+            var listaFormatos = new List<IdNomeTipoExcluidoDTO> { new IdNomeTipoExcluidoDTO { Id = 2L, Nome = "JPEG", Tipo = (int)TipoFormato.ACERVO_FOTOS } };
+            servicoFormatoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaFormatos);
+
+            var listaSuportes = new List<IdNomeTipoExcluidoDTO> { new IdNomeTipoExcluidoDTO { Id = 3L, Nome = "Digital", Tipo = (int)TipoSuporte.IMAGEM } };
+            servicoSuporteMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaSuportes);
+
+            var listaConservacao = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 4L, Nome = "Bom" } };
+            servicoConservacaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaConservacao);
+
+            var listaCromia = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 5L, Nome = "Colorido" } };
+            servicoCromiaMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaCromia);
+
+            // Mockando Retornos genéricos vazios com seus tipos concretos para o restante
+            servicoIdiomaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoMaterialMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoAcessoDocumentoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoEditoraMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoSerieColecaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoAssuntoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+
+            // Mapeador simulando o comportamento do AutoMapper
+            mapperMock.Setup(m => m.Map<IdNomeDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeDTO { Id = s.Id, Nome = s.Nome };
+            });
+
+            mapperMock.Setup(m => m.Map<IdNomeTipoDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeTipoDTO { Id = s.Id, Nome = s.Nome, Tipo = s.Tipo };
+            });
+        }
+
+        private AcervoFotograficoLinhaDTO ObterLinhaFotograficaDTOPreenchida(int numeroLinha)
+        {
+            return new AcervoFotograficoLinhaDTO
+            {
+                NumeroLinha = numeroLinha,
+                PossuiErros = false,
+                Titulo = new LinhaConteudoAjustarDTO { Conteudo = "Foto Antiga", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Codigo = new LinhaConteudoAjustarDTO { Conteudo = "COD-001", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Credito = new LinhaConteudoAjustarDTO { Conteudo = "Autor Foto", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Localizacao = new LinhaConteudoAjustarDTO { Conteudo = "Gaveta A", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 100 },
+                Procedencia = new LinhaConteudoAjustarDTO { Conteudo = "Doação", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Data = new LinhaConteudoAjustarDTO { Conteudo = "01/01/1990", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 10 },
+                CopiaDigital = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 3 },
+                PermiteUsoImagem = new LinhaConteudoAjustarDTO { Conteudo = "Sim", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 3 },
+                EstadoConservacao = new LinhaConteudoAjustarDTO { Conteudo = "Bom", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Descricao = new LinhaConteudoAjustarDTO { Conteudo = "Imagem de teste", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Quantidade = new LinhaConteudoAjustarDTO { Conteudo = "1", FormatoTipoDeCampo = Constantes.FORMATO_INTEIRO, LimiteCaracteres = 10 },
+                Largura = new LinhaConteudoAjustarDTO { Conteudo = "10.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 10 },
+                Altura = new LinhaConteudoAjustarDTO { Conteudo = "15.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 10 },
+                Suporte = new LinhaConteudoAjustarDTO { Conteudo = "Digital", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 50 },
+                FormatoImagem = new LinhaConteudoAjustarDTO { Conteudo = "JPEG", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 50 },
+                TamanhoArquivo = new LinhaConteudoAjustarDTO { Conteudo = "2MB", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Cromia = new LinhaConteudoAjustarDTO { Conteudo = "Colorido", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 50 },
+                Resolucao = new LinhaConteudoAjustarDTO { Conteudo = "1080p", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 50 },
+                Ano = new LinhaConteudoAjustarDTO { Conteudo = "1990", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 4 }
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoTridimensionalUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/ExecutarImportacaoArquivoAcervoTridimensionalUseCaseTestes.cs
@@ -1,0 +1,344 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class ExecutarImportacaoArquivoAcervoTridimensionalUseCaseTestes
+    {
+        private readonly Mock<IRepositorioImportacaoArquivo> repositorioImportacaoArquivoMock;
+        private readonly Mock<IServicoMaterial> servicoMaterialMock;
+        private readonly Mock<IServicoEditora> servicoEditoraMock;
+        private readonly Mock<IServicoSerieColecao> servicoSerieColecaoMock;
+        private readonly Mock<IServicoIdioma> servicoIdiomaMock;
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly Mock<IServicoCreditoAutor> servicoCreditoAutorMock;
+        private readonly Mock<IServicoConservacao> servicoConservacaoMock;
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly Mock<IServicoCromia> servicoCromiaMock;
+        private readonly Mock<IServicoSuporte> servicoSuporteMock;
+        private readonly Mock<IServicoFormato> servicoFormatoMock;
+        private readonly Mock<IServicoAcervoTridimensional> servicoAcervoTridimensionalMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly ExecutarImportacaoArquivoAcervoTridimensionalUseCase sut;
+
+        public ExecutarImportacaoArquivoAcervoTridimensionalUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioImportacaoArquivoMock = mocker.GetMock<IRepositorioImportacaoArquivo>();
+            servicoMaterialMock = mocker.GetMock<IServicoMaterial>();
+            servicoEditoraMock = mocker.GetMock<IServicoEditora>();
+            servicoSerieColecaoMock = mocker.GetMock<IServicoSerieColecao>();
+            servicoIdiomaMock = mocker.GetMock<IServicoIdioma>();
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+            servicoCreditoAutorMock = mocker.GetMock<IServicoCreditoAutor>();
+            servicoConservacaoMock = mocker.GetMock<IServicoConservacao>();
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+            servicoCromiaMock = mocker.GetMock<IServicoCromia>();
+            servicoSuporteMock = mocker.GetMock<IServicoSuporte>();
+            servicoFormatoMock = mocker.GetMock<IServicoFormato>();
+            servicoAcervoTridimensionalMock = mocker.GetMock<IServicoAcervoTridimensional>();
+            mapperMock = mocker.GetMock<IMapper>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<ExecutarImportacaoArquivoAcervoTridimensionalUseCase>();
+
+            ConfigurarMocksPadroesDominios();
+        }
+
+        [Fact]
+        public void DadoDependenciasValidas_QuandoInstanciarUseCase_EntaoRetornaInstanciaComSucesso()
+        {
+            // Arrange
+            Action acao = () => new ExecutarImportacaoArquivoAcervoTridimensionalUseCase(
+                repositorioImportacaoArquivoMock.Object, servicoMaterialMock.Object, servicoEditoraMock.Object,
+                servicoSerieColecaoMock.Object, servicoIdiomaMock.Object, servicoAssuntoMock.Object,
+                servicoCreditoAutorMock.Object, servicoConservacaoMock.Object, servicoAcessoDocumentoMock.Object,
+                servicoCromiaMock.Object, servicoSuporteMock.Object, servicoFormatoMock.Object,
+                servicoAcervoTridimensionalMock.Object, mapperMock.Object, repositorioParametroSistemaMock.Object);
+
+            // Act & Assert
+            acao.Should().NotThrow();
+            sut.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "NaoNumerico" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoNaoLocalizada_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var idImportacao = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync((ImportacaoArquivo)null!);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.IMPORTACAO_NAO_LOCALIZADA);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComSucesso_QuandoExecutar_EntaoAtualizaStatusParaSucesso()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { ObterLinhaTridimensionalDTOPreenchida(1) };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.Tridimensional
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Sucesso)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoImportacaoComLinhasComErro_QuandoExecutar_EntaoAtualizaStatusParaErros()
+        {
+            // Arrange
+            var idImportacao = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = idImportacao.ToString() };
+
+            var linhaComErro = ObterLinhaTridimensionalDTOPreenchida(1);
+
+            // Forçamos um erro na revalidação usando um domínio de conservação inexistente no mock
+            linhaComErro.EstadoConservacao.Conteudo = "CONSERVACAO_INEXISTENTE";
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { linhaComErro };
+            var arquivoImportado = new ImportacaoArquivo
+            {
+                Id = idImportacao,
+                Conteudo = JsonConvert.SerializeObject(linhas),
+                TipoAcervo = TipoAcervo.Tridimensional
+            };
+
+            repositorioImportacaoArquivoMock
+                .Setup(r => r.ObterPorId(idImportacao))
+                .ReturnsAsync(arquivoImportado);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+            repositorioImportacaoArquivoMock.Verify(r => r.Salvar(It.Is<ImportacaoArquivo>(a =>
+                a.Status == ImportacaoStatus.Erros)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaCarregarDominios_QuandoExecutado_EntaoCarregaDependenciasGerais()
+        {
+            // Arrange (Mocks já configurados no construtor)
+
+            // Act
+            await sut.CarregarDominiosTridimensionais();
+
+            // Assert
+            servicoConservacaoMock.Verify(s => s.ObterTodos(), Times.Once);
+            repositorioParametroSistemaMock.Verify(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.LimiteAcervosImportadosViaPanilha, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLinhasSemErro_QuandoPersistenciaAcervo_EntaoInsereAcervoEDefineComoSucesso()
+        {
+            // Arrange
+            await sut.CarregarDominiosTridimensionais();
+
+            var linhaValida = ObterLinhaTridimensionalDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { linhaValida };
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoTridimensionalCadastroDTO>()))
+                .ReturnsAsync(1L);
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            servicoAcervoTridimensionalMock.Verify(s => s.Inserir(It.IsAny<AcervoTridimensionalCadastroDTO>()), Times.Once);
+            linhaValida.PossuiErros.Should().BeFalse();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Sucesso);
+        }
+
+        [Fact]
+        public async Task DadoErroNaInsercaoAcervo_QuandoPersistenciaAcervo_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            await sut.CarregarDominiosTridimensionais();
+
+            var linhaValida = ObterLinhaTridimensionalDTOPreenchida(1);
+            linhaValida.PossuiErros = false;
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { linhaValida };
+            var mensagemErro = "Erro interno ao salvar no banco";
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.Inserir(It.IsAny<AcervoTridimensionalCadastroDTO>()))
+                .ThrowsAsync(new Exception(mensagemErro));
+
+            // Act
+            await sut.PersistenciaAcervo(linhas);
+
+            // Assert
+            linhaValida.PossuiErros.Should().BeTrue();
+            linhaValida.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaValida.Mensagem.Should().Be(mensagemErro);
+        }
+
+        [Fact]
+        public void DadoExcecaoNaoTratadaNaValidacao_QuandoValidarPreenchimento_EntaoDefineLinhaComoErro()
+        {
+            // Arrange
+            var linhaComFalhaGrave = new AcervoTridimensionalLinhaDTO
+            {
+                NumeroLinha = 1,
+                // NullReferenceException forçado pela falta da instanciação
+                Titulo = null!
+            };
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { linhaComFalhaGrave };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaComFalhaGrave.PossuiErros.Should().BeTrue();
+            linhaComFalhaGrave.Status.Should().Be(ImportacaoStatus.Erros);
+            linhaComFalhaGrave.Mensagem.Should().Contain("Ocorreu uma falha inesperada na linha");
+        }
+
+        [Fact]
+        public void DadoLinhaComLimitesExcedidos_QuandoValidarPreenchimento_EntaoDefinePossuiErrosComoTrue()
+        {
+            // Arrange
+            var linhaInvalida = ObterLinhaTridimensionalDTOPreenchida(1);
+            linhaInvalida.Titulo.Conteudo = new string('A', 501); // Excede limite típico de 500
+
+            var linhas = new List<AcervoTridimensionalLinhaDTO> { linhaInvalida };
+
+            // Act
+            sut.ValidarPreenchimentoValorFormatoQtdeCaracteres(linhas);
+
+            // Assert
+            linhaInvalida.Titulo.PossuiErro.Should().BeTrue();
+            linhaInvalida.PossuiErros.Should().BeTrue();
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroesDominios()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(It.IsAny<TipoParametroSistema>(), It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "100" });
+
+            var listaConservacao = new List<IdNomeExcluidoDTO> { new IdNomeExcluidoDTO { Id = 1L, Nome = "Bom" } };
+            servicoConservacaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(listaConservacao);
+
+            // Mockando Retornos genéricos vazios com seus tipos concretos para o restante das interfaces base
+            servicoCreditoAutorMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoAuditavelDTO>());
+            servicoSuporteMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoCromiaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoIdiomaMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoMaterialMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+            servicoAcessoDocumentoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoDTO>());
+            servicoEditoraMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoSerieColecaoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoAssuntoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeExcluidoAuditavelDTO>());
+            servicoFormatoMock.Setup(s => s.ObterTodos()).ReturnsAsync(new List<IdNomeTipoExcluidoDTO>());
+
+            // Mapeador simulando o comportamento do AutoMapper
+            mapperMock.Setup(m => m.Map<IdNomeDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeDTO { Id = s.Id, Nome = s.Nome };
+            });
+
+            mapperMock.Setup(m => m.Map<IdNomeTipoDTO>(It.IsAny<object>())).Returns((object src) =>
+            {
+                var s = src as dynamic;
+                return new IdNomeTipoDTO { Id = s.Id, Nome = s.Nome, Tipo = s.Tipo };
+            });
+        }
+
+        private AcervoTridimensionalLinhaDTO ObterLinhaTridimensionalDTOPreenchida(int numeroLinha)
+        {
+            return new AcervoTridimensionalLinhaDTO
+            {
+                NumeroLinha = numeroLinha,
+                PossuiErros = false,
+                Titulo = new LinhaConteudoAjustarDTO { Conteudo = "Peça Histórica", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Codigo = new LinhaConteudoAjustarDTO { Conteudo = "COD-TR1", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Procedencia = new LinhaConteudoAjustarDTO { Conteudo = "Doação", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 200 },
+                Ano = new LinhaConteudoAjustarDTO { Conteudo = "2020", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 7 },
+                EstadoConservacao = new LinhaConteudoAjustarDTO { Conteudo = "Bom", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Quantidade = new LinhaConteudoAjustarDTO { Conteudo = "1", FormatoTipoDeCampo = Constantes.FORMATO_INTEIRO, LimiteCaracteres = 10 },
+                Descricao = new LinhaConteudoAjustarDTO { Conteudo = "Descrição da peça", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 500 },
+                Largura = new LinhaConteudoAjustarDTO { Conteudo = "50.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Altura = new LinhaConteudoAjustarDTO { Conteudo = "100.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Profundidade = new LinhaConteudoAjustarDTO { Conteudo = "40.0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 },
+                Diametro = new LinhaConteudoAjustarDTO { Conteudo = "0", FormatoTipoDeCampo = Constantes.FORMATO_STRING, LimiteCaracteres = 15 }
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoItemUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoItemUseCaseTestes.cs
@@ -1,0 +1,210 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class NotificarViaEmailCancelamentoAtendimentoItemUseCaseTestes
+    {
+        private readonly Mock<IRepositorioAcervoSolicitacaoItem> repositorioAcervoSolicitacaoItemMock;
+        private readonly Mock<IServicoNotificacaoEmail> servicoNotificacaoEmailMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase sut;
+
+        public NotificarViaEmailCancelamentoAtendimentoItemUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioAcervoSolicitacaoItemMock = mocker.GetMock<IRepositorioAcervoSolicitacaoItem>();
+            servicoNotificacaoEmailMock = mocker.GetMock<IServicoNotificacaoEmail>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<NotificarViaEmailCancelamentoAtendimentoItemUseCaseUseCase>();
+
+            ConfigurarMocksPadroes();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "ID_INVALIDO" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoVazia_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoItemId.ToString() };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(null, acervoSolicitacaoItemId))
+                .ReturnsAsync(new List<AcervoSolicitacaoItemDetalhe>());
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITACAO_ATENDIMENTO_NAO_CONTEM_ACERVOS);
+        }
+
+        [Fact]
+        public async Task DadoItemCujoSolicitanteNaoPossuiEmail_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoItemId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe { Email = "   " } // Testando string.IsNullOrWhiteSpace
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(null, acervoSolicitacaoItemId))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITANTE_NAO_POSSUI_EMAIL);
+        }
+
+        [Fact]
+        public async Task DadoItemCanceladoValido_QuandoExecutar_EntaoConstroiEnviaEmailERetornaTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = 1L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoItemId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    AcervoSolicitacaoId = 10,
+                    Id = acervoSolicitacaoItemId,
+                    Solicitante = "Carlos Almeida",
+                    Email = "carlos@email.com",
+                    Titulo = "Fotografia Antiga",
+                    TipoAcervo = TipoAcervo.Fotografico,
+                    Codigo = "FOTO01",
+                    CodigoNovo = "NFOTO01",
+                    DataVisita = new DateTime(2026, 08, 15, 10, 0, 0)
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(null, acervoSolicitacaoItemId))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+
+            servicoNotificacaoEmailMock.Verify(s => s.Enviar(
+                "Carlos Almeida",
+                "carlos@email.com",
+                "CDEP - Atendimento item cancelado",
+                It.Is<string>(html =>
+                    html.Contains("Olá Carlos Almeida") &&
+                    html.Contains("http://cdep.com/contato") &&
+                    html.Contains("Fotografia Antiga") &&
+                    html.Contains("Fotográfico") &&
+                    html.Contains("15/08 10:00") &&
+                    html.Contains("FOTO01/NFOTO01")
+                )), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoItemSemDataDeVisita_QuandoExecutar_EntaoTabelaDeEmailExibeTracoNaData()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = 2L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoItemId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    AcervoSolicitacaoId = 10,
+                    Id = acervoSolicitacaoItemId,
+                    Solicitante = "Ana Lima",
+                    Email = "ana@email.com",
+                    Titulo = "Peça de Museu",
+                    TipoAcervo = TipoAcervo.Tridimensional,
+                    Codigo = "TRID01",
+                    DataVisita = null // Data Nula para forçar o traço
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(null, acervoSolicitacaoItemId))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+
+            servicoNotificacaoEmailMock.Verify(s => s.Enviar(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.Is<string>(html => html.Contains("<td>-</td>"))
+            ), Times.Once);
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroes()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.ModeloEmailCancelamentoSolicitacaoItem, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "<html>Olá #NOME, seu item foi cancelado. Resumo: #CONTEUDO_TABELA Dúvidas? #LINK_FORMULARIO_CDEP</html>" });
+
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.EnderecoContatoCDEPConfirmacaoCancelamentoVisita, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "http://cdep.com/contato" });
+
+            servicoNotificacaoEmailMock
+                .Setup(s => s.Enviar(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailCancelamentoAtendimentoUseCaseTestes.cs
@@ -1,0 +1,210 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class NotificarViaEmailCancelamentoAtendimentoUseCaseTestes
+    {
+        private readonly Mock<IRepositorioAcervoSolicitacaoItem> repositorioAcervoSolicitacaoItemMock;
+        private readonly Mock<IServicoNotificacaoEmail> servicoNotificacaoEmailMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase sut;
+
+        public NotificarViaEmailCancelamentoAtendimentoUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioAcervoSolicitacaoItemMock = mocker.GetMock<IRepositorioAcervoSolicitacaoItem>();
+            servicoNotificacaoEmailMock = mocker.GetMock<IServicoNotificacaoEmail>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<NotificarViaEmailCancelamentoAtendimentoUseCaseUseCase>();
+
+            ConfigurarMocksPadroes();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = null! };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComParametroNaoNumerico_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "ID_INVALIDO" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoSemItensVinculados_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var acervoSolicitacaoId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoId.ToString() };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(acervoSolicitacaoId, null))
+                .ReturnsAsync(new List<AcervoSolicitacaoItemDetalhe>());
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITACAO_ATENDIMENTO_NAO_CONTEM_ACERVOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoCujoSolicitanteNaoPossuiEmail_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var acervoSolicitacaoId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new() { Email = null }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(acervoSolicitacaoId, null))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITANTE_NAO_POSSUI_EMAIL);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoValida_QuandoExecutar_EntaoConstroiEnviaEmailERetornaTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    AcervoSolicitacaoId = 10,
+                    Id = 1,
+                    Solicitante = "João da Silva",
+                    Email = "joao@email.com",
+                    Titulo = "Livro de História",
+                    TipoAcervo = TipoAcervo.Bibliografico,
+                    Codigo = "LIV01",
+                    CodigoNovo = "NLIV01",
+                    DataVisita = new DateTime(2026, 05, 10, 14, 30, 0, DateTimeKind.Local)
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(acervoSolicitacaoId, null))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+
+            servicoNotificacaoEmailMock.Verify(s => s.Enviar(
+                "João da Silva",
+                "joao@email.com",
+                "CDEP - Atendimento cancelado",
+                It.Is<string>(html =>
+                    html.Contains("Olá João da Silva") &&
+                    html.Contains("http://cdep.com/contato") &&
+                    html.Contains("Livro de História") &&
+                    html.Contains("Bibliográfico") &&
+                    html.Contains("10/05 14:30") &&
+                    html.Contains("LIV01/NLIV01")
+                )), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoItemSemDataDeVisita_QuandoExecutar_EntaoTabelaDeEmailExibeTracoNaData()
+        {
+            // Arrange
+            var acervoSolicitacaoId = 10L;
+            var mensagemRabbit = new MensagemRabbit { Mensagem = acervoSolicitacaoId.ToString() };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    AcervoSolicitacaoId = 10,
+                    Id = 2,
+                    Solicitante = "Maria Sousa",
+                    Email = "maria@email.com",
+                    Titulo = "Peça de Museu",
+                    TipoAcervo = TipoAcervo.Tridimensional,
+                    Codigo = "TRID01",
+                    DataVisita = null // Data Nula para forçar o traço na extensão
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(acervoSolicitacaoId, null))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+
+            servicoNotificacaoEmailMock.Verify(s => s.Enviar(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.Is<string>(html => html.Contains("<td>-</td>"))
+            ), Times.Once);
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroes()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.ModeloEmailCancelamentoSolicitacao, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "<html>Olá #NOME, seu pedido foi cancelado. Resumo: #CONTEUDO_TABELA Dúvidas? #LINK_FORMULARIO_CDEP</html>" });
+
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.EnderecoContatoCDEPConfirmacaoCancelamentoVisita, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "http://cdep.com/contato" });
+
+            servicoNotificacaoEmailMock
+                .Setup(s => s.Enviar(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCaseTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/UseCase/NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCaseTestes.cs
@@ -1,0 +1,210 @@
+﻿using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using Newtonsoft.Json;
+using SME.CDEP.Aplicacao;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Infra.Servicos.Rabbit.Dto;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.UseCase
+{
+    public class NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseTestes
+    {
+        private readonly Mock<IRepositorioAcervoSolicitacaoItem> repositorioAcervoSolicitacaoItemMock;
+        private readonly Mock<IServicoNotificacaoEmail> servicoNotificacaoEmailMock;
+        private readonly Mock<IRepositorioParametroSistema> repositorioParametroSistemaMock;
+        private readonly NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase sut;
+
+        public NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseTestes()
+        {
+            var mocker = new AutoMocker();
+
+            repositorioAcervoSolicitacaoItemMock = mocker.GetMock<IRepositorioAcervoSolicitacaoItem>();
+            servicoNotificacaoEmailMock = mocker.GetMock<IServicoNotificacaoEmail>();
+            repositorioParametroSistemaMock = mocker.GetMock<IRepositorioParametroSistema>();
+
+            sut = mocker.CreateInstance<NotificarViaEmailConfirmacaoAtendimentoPresencialUseCaseUseCase>();
+
+            ConfigurarMocksPadroes();
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComDtoNulo_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var mensagemRabbit = new MensagemRabbit { Mensagem = "null" };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoMensagemRabbitComIdInvalido_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dtoInvalido = new ConfirmarAtendimentoDTO { Id = -1, ItemId = 0 };
+            var mensagemRabbit = new MensagemRabbit { Mensagem = JsonConvert.SerializeObject(dtoInvalido) };
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.PARAMETROS_INVALIDOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitanteSemEmail_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new ConfirmarAtendimentoDTO { Id = 10L, ItemId = 10 };
+            var mensagemRabbit = new MensagemRabbit { Mensagem = JsonConvert.SerializeObject(dto) };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new() { Email = string.Empty }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(It.IsAny<long>(), It.IsAny<long>()))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITANTE_NAO_POSSUI_EMAIL);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoVazia_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new ConfirmarAtendimentoDTO { Id = 10L, ItemId = 10 };
+            var mensagemRabbit = new MensagemRabbit { Mensagem = JsonConvert.SerializeObject(dto) };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(It.IsAny<long>(), It.IsAny<long>()))
+                .ReturnsAsync(new List<AcervoSolicitacaoItemDetalhe>());
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITACAO_ATENDIMENTO_NAO_CONTEM_ACERVOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoSemAtendimentoPresencial_QuandoExecutar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new ConfirmarAtendimentoDTO { Id = 10L, ItemId = 10 };
+            var mensagemRabbit = new MensagemRabbit { Mensagem = JsonConvert.SerializeObject(dto) };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    Email = "teste@teste.com",
+                    TipoAtendimento = TipoAtendimento.Email
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(It.IsAny<long>(), It.IsAny<long>()))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            Func<Task> acao = async () => await sut.Executar(mensagemRabbit);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.SOLICITACAO_ATENDIMENTO_NAO_CONTEM_ACERVOS);
+        }
+
+        [Fact]
+        public async Task DadoSolicitacaoPresencialValida_QuandoExecutar_EntaoEnviaEmailComParametrosSubstituidosERetornaTrue()
+        {
+            // Arrange
+            var dto = new ConfirmarAtendimentoDTO { Id = 10L, ItemId = 10 };
+            var mensagemRabbit = new MensagemRabbit { Mensagem = JsonConvert.SerializeObject(dto) };
+
+            var detalhes = new List<AcervoSolicitacaoItemDetalhe>
+            {
+                new AcervoSolicitacaoItemDetalhe
+                {
+                    AcervoSolicitacaoId = 10,
+                    Id = 1,
+                    Solicitante = "Maria Oliveira",
+                    Email = "maria@email.com",
+                    Titulo = "Documento Histórico",
+                    TipoAcervo = TipoAcervo.DocumentacaoTextual,
+                    TipoAtendimento = TipoAtendimento.Presencial,
+                    Codigo = "DOC01",
+                    DataVisita = new DateTime(2026, 12, 01, 10, 0, 0, DateTimeKind.Local)
+                }
+            };
+
+            repositorioAcervoSolicitacaoItemMock
+                .Setup(r => r.ObterDetalhamentoDosItensPorSolicitacaoOuItem(It.IsAny<long>(), It.IsAny<long>()))
+                .ReturnsAsync(detalhes);
+
+            // Act
+            var resultado = await sut.Executar(mensagemRabbit);
+
+            // Assert
+            resultado.Should().BeTrue();
+
+            servicoNotificacaoEmailMock.Verify(s => s.Enviar(
+                "Maria Oliveira",
+                "maria@email.com",
+                "CDEP - Confirmação de Atendimento",
+                It.Is<string>(html =>
+                    html.Contains("Olá Maria Oliveira") &&
+                    html.Contains("http://cdep.com/contato") &&
+                    html.Contains("Rua Sede CDEP, 123") &&
+                    html.Contains("08:00 as 17:00") &&
+                    html.Contains("Documento Histórico") &&
+                    html.Contains("01/12 10:00") &&
+                    html.Contains("DOC01")
+                )), Times.Once);
+        }
+
+        // ================= MÉTODOS PRIVADOS AUXILIARES ================= //
+
+        private void ConfigurarMocksPadroes()
+        {
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.ModeloEmailConfirmacaoSolicitacao, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "Olá #NOME. Resumo: #CONTEUDO_TABELA. Contato: #LINK_FORMULARIO_CDEP. Endereço: #ENDERECO_SEDE_CDEP_VISITA. Horário: #HORARIO_FUNCIONAMENTO_SEDE_CDEP" });
+
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.EnderecoContatoCDEPConfirmacaoCancelamentoVisita, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "http://cdep.com/contato" });
+
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.EnderecoSedeCDEPVisita, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "Rua Sede CDEP, 123" });
+
+            repositorioParametroSistemaMock
+                .Setup(p => p.ObterParametroPorTipoEAno(TipoParametroSistema.HorarioFuncionamentoSedeCDEPVisita, It.IsAny<int>()))
+                .ReturnsAsync(new ParametroSistema { Valor = "08:00 as 17:00" });
+
+            servicoNotificacaoEmailMock
+                .Setup(s => s.Enviar(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Domain/Extensions/DateTimeExtensionTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Domain/Extensions/DateTimeExtensionTestes.cs
@@ -1,0 +1,255 @@
+﻿using FluentAssertions;
+using SME.CDEP.Dominio.Extensions;
+
+namespace SME.CDEP.TesteUnitario.Domain.Extensions
+{
+    public class DateTimeExtensionTestes
+    {
+        [Fact]
+        public void DadoData_QuandoLocal_EntaoRetornaMesmaData()
+        {
+            // Arrange
+            var data = new DateTime(2026, 4, 13, 10, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.Local();
+
+            // Assert
+            resultado.Should().Be(data);
+        }
+
+        [Fact]
+        public void DadoChamada_QuandoHorarioBrasilia_EntaoRetornaDataHoraAtualMenosTresHoras()
+        {
+            // Arrange
+            var dataHoraEsperada = DateTime.UtcNow.AddHours(-3);
+
+            // Act
+            var resultado = DateTimeExtension.HorarioBrasilia();
+
+            // Assert
+            resultado.Should().BeCloseTo(dataHoraEsperada, TimeSpan.FromSeconds(1));
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 15, 2026, 4, 12)] // Quarta-feira -> Retorna Domingo anterior
+        [InlineData(2026, 4, 12, 2026, 4, 12)] // Domingo -> Retorna mesmo dia
+        [InlineData(2026, 4, 13, 2026, 4, 12)] // Segunda-feira -> Retorna Domingo anterior
+        public void DadoDataQualquer_QuandoObterDomingo_EntaoRetornaDomingoDaSemana(int ano, int mes, int dia, int anoEsp, int mesEsp, int diaEsp)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+            var domingoEsperado = new DateTime(anoEsp, mesEsp, diaEsp, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.ObterDomingo();
+
+            // Assert
+            resultado.Date.Should().Be(domingoEsperado.Date);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 15, 2026, 4, 18)] // Quarta-feira -> Retorna Sábado seguinte
+        [InlineData(2026, 4, 18, 2026, 4, 18)] // Sábado -> Retorna mesmo dia
+        [InlineData(2026, 4, 17, 2026, 4, 18)] // Sexta-feira -> Retorna Sábado seguinte
+        public void DadoDataQualquer_QuandoObterSabado_EntaoRetornaSabadoDaSemana(int ano, int mes, int dia, int anoEsp, int mesEsp, int diaEsp)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+            var sabadoEsperado = new DateTime(anoEsp, mesEsp, diaEsp, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.ObterSabado();
+
+            // Assert
+            resultado.Date.Should().Be(sabadoEsperado.Date);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 18, true)]  // Sábado
+        [InlineData(2026, 4, 19, true)]  // Domingo
+        [InlineData(2026, 4, 15, false)] // Quarta-feira
+        public void DadoData_QuandoFimDeSemana_EntaoRetornaResultadoEsperado(int ano, int mes, int dia, bool esperado)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.FimDeSemana();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 19, true)]  // Domingo
+        [InlineData(2026, 4, 18, false)] // Sábado
+        [InlineData(2026, 4, 15, false)] // Quarta-feira
+        public void DadoData_QuandoDomingo_EntaoRetornaResultadoEsperado(int ano, int mes, int dia, bool esperado)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.Domingo();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(2026, 1, 15, 1)] // Janeiro -> Semestre 1
+        [InlineData(2026, 6, 30, 1)] // Junho -> Semestre 1
+        [InlineData(2026, 7, 1, 2)]  // Julho -> Semestre 2
+        [InlineData(2026, 12, 31, 2)] // Dezembro -> Semestre 2
+        public void DadoData_QuandoSemestre_EntaoRetornaSemestreCorreto(int ano, int mes, int dia, int semestreEsperado)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.Semestre();
+
+            // Assert
+            resultado.Should().Be(semestreEsperado);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 15, 1, 2026, 4, 14)] // Quarta-feira, menos 1 dia util = Terça-feira
+        [InlineData(2026, 4, 15, 2, 2026, 4, 13)] // Quarta-feira, menos 2 dias uteis = Segunda-feira
+        [InlineData(2026, 4, 13, 2, 2026, 4, 9)]  // Segunda-feira, menos 2 dias uteis = Quinta-feira da semana anterior (pula FDS)
+        public void DadoData_QuandoDiaRetroativo_EntaoRetornaDataPulandoFinaisDeSemana(int ano, int mes, int dia, int nrDias, int anoEsp, int mesEsp, int diaEsp)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+            var dataEsperada = new DateTime(anoEsp, mesEsp, diaEsp, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.DiaRetroativo(nrDias);
+
+            // Assert
+            resultado.Should().Be(dataEsperada);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 15, 2026, 4, 12)] // Quarta-feira -> Retorna Domingo anterior
+        [InlineData(2026, 4, 12, 2026, 4, 12)] // Domingo -> Retorna mesmo dia
+        [InlineData(2026, 4, 13, 2026, 4, 12)] // Segunda-feira -> Retorna Domingo anterior
+        public void DadoData_QuandoObterDomingoRetroativo_EntaoRetornaDomingoCorreto(int ano, int mes, int dia, int anoEsp, int mesEsp, int diaEsp)
+        {
+            // Arrange
+            var data = new DateTime(ano, mes, dia, 0, 0, 0, DateTimeKind.Local);
+            var domingoEsperado = new DateTime(anoEsp, mesEsp, diaEsp, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = data.ObterDomingoRetroativo();
+
+            // Assert
+            resultado.Date.Should().Be(domingoEsperado.Date);
+        }
+
+        [Fact]
+        public void DadoDatasNulaveis_QuandoVerificarEhMaiorOuIgualQue_EntaoRetornaFalsoSeUmaForNula()
+        {
+            // Arrange
+            DateTime? dataNula = null;
+            DateTime? dataValida = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
+            // Act & Assert
+            dataNula.EhMaiorOuIgualQue(dataValida).Should().BeFalse();
+            dataValida.EhMaiorOuIgualQue(dataNula).Should().BeFalse();
+            dataNula.EhMaiorOuIgualQue(dataNula).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 15, 2026, 4, 14, true)]  // Avaliada > Referencia
+        [InlineData(2026, 4, 15, 2026, 4, 15, true)]  // Avaliada == Referencia
+        [InlineData(2026, 4, 15, 2026, 4, 16, false)] // Avaliada < Referencia
+        public void DadoDatasValidas_QuandoEhMaiorOuIgualQue_EntaoRetornaResultadoEsperado(int anoAv, int mesAv, int diaAv, int anoRef, int mesRef, int diaRef, bool esperado)
+        {
+            // Arrange
+            DateTime? dataAvaliada = new DateTime(anoAv, mesAv, diaAv, 0, 0, 0, DateTimeKind.Local);
+            DateTime? dataReferencia = new DateTime(anoRef, mesRef, diaRef, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultado = dataAvaliada.EhMaiorOuIgualQue(dataReferencia);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 14, 2026, 4, 15, true)]  // Avaliada < Referencia
+        [InlineData(2026, 4, 15, 2026, 4, 15, false)] // Avaliada == Referencia
+        [InlineData(2026, 4, 16, 2026, 4, 15, false)] // Avaliada > Referencia
+        public void DadoDatasValidas_QuandoEhMenorQue_EntaoRetornaResultadoEsperado(int anoAv, int mesAv, int diaAv, int anoRef, int mesRef, int diaRef, bool esperado)
+        {
+            // Arrange
+            DateTime? dataAvaliada = new DateTime(anoAv, mesAv, diaAv, 0, 0, 0, DateTimeKind.Local);
+            DateTime? dataReferencia = new DateTime(anoRef, mesRef, diaRef, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultadoNulavel = dataAvaliada.EhMenorQue(dataReferencia);
+            var resultadoNaoNulavel = dataAvaliada.Value.EhMenorQue(dataReferencia.Value);
+
+            // Assert
+            resultadoNulavel.Should().Be(esperado);
+            resultadoNaoNulavel.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(2026, 4, 14, 2026, 4, 15, true)]  // Avaliada < Referencia
+        [InlineData(2026, 4, 15, 2026, 4, 15, true)]  // Avaliada == Referencia
+        [InlineData(2026, 4, 16, 2026, 4, 15, false)] // Avaliada > Referencia
+        public void DadoDatasValidas_QuandoEhMenorIgualQue_EntaoRetornaResultadoEsperado(int anoAv, int mesAv, int diaAv, int anoRef, int mesRef, int diaRef, bool esperado)
+        {
+            // Arrange
+            DateTime? dataAvaliada = new DateTime(anoAv, mesAv, diaAv, 0, 0, 0, DateTimeKind.Local);
+            DateTime? dataReferencia = new DateTime(anoRef, mesRef, diaRef, 0, 0, 0, DateTimeKind.Local);
+
+            // Act
+            var resultadoNulavel = dataAvaliada.EhMenorIgualQue(dataReferencia);
+            var resultadoNaoNulavel = dataAvaliada.Value.EhMenorIgualQue(dataReferencia.Value);
+
+            // Assert
+            resultadoNulavel.Should().Be(esperado);
+            resultadoNaoNulavel.Should().Be(esperado);
+        }
+
+        [Fact]
+        public void DadoDataNula_QuandoAvaliarSeEhDataFutura_EntaoRetornaFalsoParaAmbos()
+        {
+            // Arrange
+            DateTime? dataNula = null;
+
+            // Act
+            var ehFutura = dataNula.EhDataFutura();
+            var naoEhFutura = dataNula.NaoEhDataFutura();
+
+            // Assert
+            ehFutura.Should().BeFalse();
+            naoEhFutura.Should().BeFalse();
+        }
+
+        [Fact]
+        public void DadoData_QuandoEhDataFutura_EntaoAvaliaCorretamenteEmRelacaoABrasilia()
+        {
+            // Arrange
+            DateTime dataFutura = DateTimeExtension.HorarioBrasilia().AddDays(1);
+            DateTime dataPassada = DateTimeExtension.HorarioBrasilia().AddDays(-1);
+
+            DateTime? dataFuturaNulavel = dataFutura;
+            DateTime? dataPassadaNulavel = dataPassada;
+
+            // Act & Assert
+            dataFutura.EhDataFutura().Should().BeTrue();
+            dataFutura.NaoEhDataFutura().Should().BeFalse();
+
+            dataPassada.EhDataFutura().Should().BeFalse();
+            dataPassada.NaoEhDataFutura().Should().BeTrue();
+
+            dataFuturaNulavel.EhDataFutura().Should().BeTrue();
+            dataPassadaNulavel.EhDataFutura().Should().BeFalse();
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Domain/Extensions/DoubleExtensionTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Domain/Extensions/DoubleExtensionTestes.cs
@@ -1,0 +1,185 @@
+﻿using FluentAssertions;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
+
+namespace SME.CDEP.TesteUnitario.Domain.Extensions
+{
+    public class DoubleExtensionTestes
+    {
+        [Theory]
+        [InlineData(10.5)]
+        [InlineData(100)]
+        [InlineData(0)]
+        [InlineData(-5.5)]
+        public void DadoStringComValorNumerico_QuandoObterDoubleOuNuloPorValorDoCampo_EntaoRetornaValorConvertido(double valorEsperado)
+        {
+            // Arrange
+            var valorFormatadoParaParse = valorEsperado.ToString();
+
+            // Act
+            var resultado = valorFormatadoParaParse.ObterDoubleOuNuloPorValorDoCampo();
+
+            // Assert
+            resultado.Should().Be(valorEsperado);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void DadoStringVaziaOuNula_QuandoObterDoubleOuNuloPorValorDoCampo_EntaoRetornaNulo(string? valorOriginal)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal!.ObterDoubleOuNuloPorValorDoCampo();
+
+            // Assert
+            resultado.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData("True", true)]
+        [InlineData("False", false)]
+        public void DadoStringComValorBooleano_QuandoObterBooleanoPorValorDoCampo_EntaoRetornaValorConvertido(string valorOriginal, bool valorEsperado)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal.ObterBooleanoPorValorDoCampo();
+
+            // Assert
+            resultado.Should().Be(valorEsperado);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void DadoStringVaziaOuNula_QuandoObterBooleanoPorValorDoCampo_EntaoRetornaFalso(string? valorOriginal)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal!.ObterBooleanoPorValorDoCampo();
+
+            // Assert
+            resultado.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(10.5)]
+        [InlineData(100)]
+        public void DadoStringComValorNumerico_QuandoObterDoublePorValorDoCampo_EntaoRetornaValorConvertido(double valorEsperado)
+        {
+            // Arrange
+            var valorFormatadoParaParse = valorEsperado.ToString();
+
+            // Act
+            var resultado = valorFormatadoParaParse.ObterDoublePorValorDoCampo();
+
+            // Assert
+            resultado.Should().Be(valorEsperado);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void DadoStringVaziaOuNula_QuandoObterDoublePorValorDoCampo_EntaoLancaNegocioException(string? valorOriginal)
+        {
+            // Arrange
+            Action acao = () => valorOriginal!.ObterDoublePorValorDoCampo();
+
+            // Act & Assert
+            acao.Should().Throw<NegocioException>();
+        }
+
+        [Theory]
+        [InlineData(10.5, 10.5, true)]
+        [InlineData(10.5, 10.6, false)]
+        [InlineData(0, 0, true)]
+        [InlineData(100, -100, false)]
+        public void DadoDoisValoresDouble_QuandoSaoIguais_EntaoRetornaVerdadeiroSeForemIguais(double valor1, double valor2, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor1.SaoIguais(valor2);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(10.5, 10.5, true)]
+        [InlineData(10.5, 10.6, false)]
+        [InlineData(null, null, true)]
+        [InlineData(10.5, null, false)]
+        [InlineData(null, 10.5, false)]
+        public void DadoDoisValoresDoubleNulaveis_QuandoSaoIguais_EntaoRetornaVerdadeiroSeForemIguaisOuAmbosNulos(double? valor1, double? valor2, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor1.SaoIguais(valor2);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Fact]
+        public void DadoValorNulo_QuandoFormatarParaDoubleComCasasDecimais_EntaoRetornaNulo()
+        {
+            // Arrange
+            double? valor = null;
+
+            // Act
+            var resultado = valor.FormatarParaDoubleComCasasDecimais();
+
+            // Assert
+            resultado.Should().BeNull();
+        }
+
+        [Fact]
+        public void DadoValorComVirgulaOuPonto_QuandoFormatarParaDoubleComCasasDecimaisNulavel_EntaoRetornaMesmoValor()
+        {
+            // Arrange
+            double? valor = 10.5;
+
+            // Act
+            var resultado = valor.FormatarParaDoubleComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(valor);
+        }
+
+        [Fact]
+        public void DadoValorInteiroSemCasas_QuandoFormatarParaDoubleComCasasDecimaisNulavel_EntaoRetornaValorDivididoPorCem()
+        {
+            // Arrange
+            double? valor = 1000; // Representando 10,00 sem vírgula
+
+            // Act
+            var resultado = valor.FormatarParaDoubleComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(10); // 1000 / 100 = 10
+        }
+
+        [Fact]
+        public void DadoValorComVirgulaOuPonto_QuandoFormatarDoubleComCasasDecimais_EntaoRetornaMesmoValor()
+        {
+            // Arrange
+            double valor = 15.5;
+
+            // Act
+            var resultado = valor.FormatarDoubleComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(valor);
+        }
+
+        [Fact]
+        public void DadoValorInteiroSemCasas_QuandoFormatarDoubleComCasasDecimais_EntaoRetornaValorDivididoPorCem()
+        {
+            // Arrange
+            double valor = 2500; // Representando 25,00 sem vírgula
+
+            // Act
+            var resultado = valor.FormatarDoubleComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(25); // 2500 / 100 = 25
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Domain/Extensions/EnumExtensionTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Domain/Extensions/EnumExtensionTestes.cs
@@ -1,0 +1,79 @@
+﻿using FluentAssertions;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Dominio.Extensions;
+
+namespace SME.CDEP.TesteUnitario.Domain.Extensions
+{
+    public class EnumExtensionTestes
+    {
+        [Theory]
+        [InlineData(TipoAcervo.DocumentacaoTextual, false)]
+        [InlineData(TipoAcervo.Bibliografico, true)]
+        [InlineData(TipoAcervo.Audiovisual, true)]
+        public void DadoTipoAcervo_QuandoNaoEhAcervoDocumental_EntaoRetornaResultadoEsperado(TipoAcervo tipoAcervo, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = tipoAcervo.NaoEhAcervoDocumental();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(TipoAcervo.Bibliografico, true)]
+        [InlineData(TipoAcervo.DocumentacaoTextual, false)]
+        [InlineData(TipoAcervo.Fotografico, false)]
+        public void DadoTipoAcervo_QuandoEhAcervoBibliografico_EntaoRetornaResultadoEsperado(TipoAcervo tipoAcervo, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = tipoAcervo.EhAcervoBibliografico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(TipoAcervo.Bibliografico, false)]
+        [InlineData(TipoAcervo.DocumentacaoTextual, true)]
+        [InlineData(TipoAcervo.Tridimensional, true)]
+        public void DadoTipoAcervo_QuandoNaoEhAcervoBibliografico_EntaoRetornaResultadoEsperado(TipoAcervo tipoAcervo, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = tipoAcervo.NaoEhAcervoBibliografico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(TipoAcervo.Bibliografico, Constantes.PLANILHA_ACERVO_BIBLIOGRAFICO)]
+        [InlineData(TipoAcervo.DocumentacaoTextual, Constantes.PLANILHA_ACERVO_DOCUMENTAL)]
+        [InlineData(TipoAcervo.ArtesGraficas, Constantes.PLANILHA_ACERVO_ARTE_GRAFICA)]
+        [InlineData(TipoAcervo.Audiovisual, Constantes.PLANILHA_ACERVO_AUDIOVISUAL)]
+        [InlineData(TipoAcervo.Fotografico, Constantes.PLANILHA_ACERVO_FOTOGRAFICO)]
+        [InlineData(TipoAcervo.Tridimensional, Constantes.PLANILHA_ACERVO_TRIDIMENSIONAL)]
+        public void DadoTipoAcervoValido_QuandoObterPlanilhaModelo_EntaoRetornaNomeDaPlanilhaConstante(TipoAcervo tipoAcervo, string planilhaEsperada)
+        {
+            // Arrange & Act
+            var resultado = tipoAcervo.ObterPlanilhaModelo();
+
+            // Assert
+            resultado.Should().Be(planilhaEsperada);
+        }
+
+        [Fact]
+        public void DadoTipoAcervoInvalido_QuandoObterPlanilhaModelo_EntaoLancaArgumentOutOfRangeException()
+        {
+            // Arrange
+            var tipoAcervoInvalido = (TipoAcervo)999;
+
+            // Act
+            Action acao = () => tipoAcervoInvalido.ObterPlanilhaModelo();
+
+            // Assert
+            acao.Should().Throw<ArgumentOutOfRangeException>()
+                .WithParameterName("tipoAcervo");
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Domain/Extensions/LongExtensionTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Domain/Extensions/LongExtensionTestes.cs
@@ -1,0 +1,214 @@
+﻿using FluentAssertions;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Dominio.Extensions;
+using SME.CDEP.Infra.Dominio.Enumerados;
+
+namespace SME.CDEP.TesteUnitario.Domain.Extensions
+{
+    public class LongExtensionTestes
+    {
+        [Theory]
+        [InlineData((long)TipoAcervo.DocumentacaoTextual, true)]
+        [InlineData((long)TipoAcervo.Bibliografico, false)]
+        public void DadoValor_QuandoEhAcervoDocumental_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoDocumental();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Tridimensional, true)]
+        [InlineData((long)TipoAcervo.DocumentacaoTextual, false)]
+        public void DadoValor_QuandoEhAcervoTridimensional_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoTridimensional();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Bibliografico, true)]
+        [InlineData((long)TipoAcervo.Audiovisual, false)]
+        public void DadoValor_QuandoEhAcervoBibliografico_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoBibliografico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Audiovisual, true)]
+        [InlineData((long)TipoAcervo.Bibliografico, false)]
+        public void DadoValor_QuandoNaoEhAcervoBibliografico_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.NaoEhAcervoBibliografico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.ArtesGraficas, true)]
+        [InlineData((long)TipoAcervo.Fotografico, false)]
+        public void DadoValor_QuandoEhAcervoArteGrafica_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoArteGrafica();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Fotografico, true)]
+        [InlineData((long)TipoAcervo.DocumentacaoTextual, false)]
+        public void DadoValor_QuandoEhAcervoFotografico_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoFotografico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Audiovisual, true)]
+        [InlineData((long)TipoAcervo.Tridimensional, false)]
+        public void DadoValor_QuandoEhAcervoAudiovisual_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAcervoAudiovisual();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData((long)TipoAcervo.Bibliografico, true)]
+        [InlineData((long)TipoAcervo.DocumentacaoTextual, false)]
+        public void DadoValor_QuandoNaoEhAcervoDocumental_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.NaoEhAcervoDocumental();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(1, true)]
+        [InlineData(100, true)]
+        [InlineData(0, false)]
+        [InlineData(-1, false)]
+        public void DadoValor_QuandoEhMaiorQueZero_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhMaiorQueZero();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(-5, true)]
+        [InlineData(1, false)]
+        [InlineData(50, false)]
+        public void DadoValor_QuandoEhMenorIgualQueZero_EntaoRetornaResultadoEsperado(long valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhMenorIgualQueZero();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("10", 10)]
+        [InlineData("99999999", 99999999)]
+        [InlineData("-50", -50)]
+        public void DadoStringComValorNumerico_QuandoObterLongoOuNuloPorValorDoCampo_EntaoRetornaValorConvertido(string valorOriginal, long valorEsperado)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal.ObterLongoOuNuloPorValorDoCampo();
+
+            // Assert
+            resultado.Should().Be(valorEsperado);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void DadoStringVaziaOuNula_QuandoObterLongoOuNuloPorValorDoCampo_EntaoRetornaNulo(string? valorOriginal)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal!.ObterLongoOuNuloPorValorDoCampo();
+
+            // Assert
+            resultado.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("100", 100)]
+        [InlineData("-50", -50)]
+        public void DadoStringComValorNumerico_QuandoObterLongoPorValorDoCampo_EntaoRetornaValorConvertido(string valorOriginal, long valorEsperado)
+        {
+            // Arrange & Act
+            var resultado = valorOriginal.ObterLongoPorValorDoCampo();
+
+            // Assert
+            resultado.Should().Be(valorEsperado);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("abc")]
+        [InlineData("10.5")]
+        public void DadoStringInvalida_QuandoObterLongoPorValorDoCampo_EntaoLancaNegocioException(string? valorOriginal)
+        {
+            // Arrange
+            Action acao = () => valorOriginal!.ObterLongoPorValorDoCampo();
+
+            // Act & Assert
+            acao.Should().Throw<NegocioException>();
+        }
+
+        [Theory]
+        [InlineData(10, 10, true)]
+        [InlineData(10, 15, false)]
+        [InlineData(0, 0, true)]
+        [InlineData(-5, 5, false)]
+        public void DadoValoresLongos_QuandoSaoIguais_EntaoRetornaResultadoEsperado(long valor1, long valor2, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor1.SaoIguais(valor2);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(10L, 10L, true)]
+        [InlineData(10L, 15L, false)]
+        [InlineData(null, null, true)]
+        [InlineData(10L, null, false)]
+        [InlineData(null, 10L, false)]
+        public void DadoValoresLongosNulaveis_QuandoSaoIguais_EntaoRetornaResultadoEsperado(long? valor1, long? valor2, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor1.SaoIguais(valor2);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/Domain/Extensions/StringExtensionTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Domain/Extensions/StringExtensionTestes.cs
@@ -1,0 +1,431 @@
+﻿using FluentAssertions;
+using SME.CDEP.Dominio.Extensions;
+
+namespace SME.CDEP.TesteUnitario.Domain.Extensions
+{
+    public class StringExtensionTestes
+    {
+        [Theory]
+        [InlineData(".jpg", true)]
+        [InlineData(".jpeg", true)]
+        [InlineData(".png", true)]
+        [InlineData(".tiff", true)]
+        [InlineData(".tif", true)]
+        [InlineData(".pdf", false)]
+        [InlineData(".txt", false)]
+        public void DadoExtensao_QuandoEhExtensaoImagemGerarMiniatura_EntaoRetornaResultadoEsperado(string extensao, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = extensao.EhExtensaoImagemGerarMiniatura();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("foto.jpg", true)]
+        [InlineData("documento.pdf", false)]
+        public void DadoNomeArquivo_QuandoEhArquivoImagemParaOtimizar_EntaoRetornaResultadoEsperado(string nomeArquivo, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = nomeArquivo.EhArquivoImagemParaOtimizar();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("DOCUMENTO.FT", ".FT", true)]
+        [InlineData("DOCUMENTO.AG", ".AG", true)]
+        [InlineData("DOCUMENTO.PDF", ".FT", false)]
+        public void DadoString_QuandoContemSigla_EntaoRetornaResultadoEsperado(string valor, string sigla, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.ContemSigla(sigla);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("ABCD", "A")]
+        [InlineData("ABC", "")]
+        [InlineData("AB", "")]
+        public void DadoString_QuandoRemoverSufixo_EntaoRetornaStringSemOsTresUltimosCaracteres(string valor, string esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.RemoverSufixo();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("Texto", true)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void DadoString_QuandoEstaPreenchido_EntaoRetornaResultadoEsperado(string? valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.EstaPreenchido();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("Texto", false)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        public void DadoString_QuandoNaoEstaPreenchido_EntaoRetornaResultadoEsperado(string? valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.NaoEstaPreenchido();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("12345", 3, "123")]
+        [InlineData("12", 5, "12")]
+        [InlineData("123", 3, "123")]
+        public void DadoString_QuandoLimite_EntaoRetornaStringLimitadaAoTamanho(string valor, int limite, string esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.Limite(limite);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("<p>Texto</p>", "Texto")]
+        [InlineData("Texto<br>Teste", "Texto Teste")]
+        [InlineData("<li>Item</li>", "Item")]
+        [InlineData("Texto&nbsp;com&nbsp;espaco", "Texto com espaco")]
+        [InlineData("", "")]
+        [InlineData(null, "")]
+        public void DadoStringHtml_QuandoRemoverTagsHtml_EntaoRetornaTextoLimpo(string? valor, string esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.RemoverTagsHtml();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", true)]
+        [InlineData("application/pdf", false)]
+        public void DadoContentType_QuandoEhArquivoXlsx_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhArquivoXlsx();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", false)]
+        [InlineData("application/pdf", true)]
+        public void DadoContentType_QuandoNaoEhArquivoXlsx_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.NaoEhArquivoXlsx();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Fact]
+        public void DadoTextoComPipes_QuandoSplitPipe_EntaoRetornaArrayDeStringsTratadas()
+        {
+            // Arrange
+            var texto = " Autor A | Autor B | Autor C ";
+
+            // Act
+            var resultado = texto.SplitPipe();
+
+            // Assert
+            resultado.Should().HaveCount(3);
+            resultado[0].Should().Be("Autor A");
+            resultado[1].Should().Be("Autor B");
+            resultado[2].Should().Be("Autor C");
+        }
+
+        [Fact]
+        public void DadoTextoComPipes_QuandoFormatarTextoEmArray_EntaoRetornaArrayDistinto()
+        {
+            // Arrange
+            var texto = "Autor A|Autor B|Autor A";
+
+            // Act
+            var resultado = texto.FormatarTextoEmArray().ToList();
+
+            // Assert
+            resultado.Should().HaveCount(2);
+            resultado.Should().Contain("Autor A");
+            resultado.Should().Contain("Autor B");
+        }
+
+        [Theory]
+        [InlineData("abc", 5, true)]
+        [InlineData("abc", 3, true)]
+        [InlineData("abcde", 3, false)]
+        [InlineData("abc", 0, true)]
+        public void DadoString_QuandoValidarLimiteDeCaracteres_EntaoRetornaResultadoEsperado(string valor, int limite, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.ValidarLimiteDeCaracteres(limite);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("string", true)]
+        [InlineData("int", false)]
+        public void DadoFormato_QuandoEhFormatoString_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhFormatoString();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("sim", true)]
+        [InlineData("SIM", true)]
+        [InlineData("não", false)]
+        public void DadoValor_QuandoEhOpcaoSim_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhOpcaoSim();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("não", true)]
+        [InlineData("NÃO", true)]
+        [InlineData("sim", false)]
+        public void DadoValor_QuandoEhOpcaoNao_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhOpcaoNao();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("Teste", "teste", true)]
+        [InlineData("Teste", "Testes", false)]
+        public void DadoValores_QuandoSaoIguais_EntaoRetornaComparacaoIgnorandoCase(string valor1, string valor2, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor1.SaoIguais(valor2);
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("10", 10)]
+        [InlineData("-5", -5)]
+        public void DadoStringNumerica_QuandoConverterParaInteiro_EntaoRetornaInteiro(string valor, int esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.ConverterParaInteiro();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData(10.5)]
+        [InlineData(10.0)]
+        public void DadoStringNumerica_QuandoConverterParaDouble_EntaoRetornaDouble(double esperado)
+        {
+            // Arrange
+            var valorStr = esperado.ToString(); // Garantindo o formato da Culture atual da thread
+
+            // Act
+            var resultado = valorStr.ConverterParaDouble();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("image/tiff", true)]
+        [InlineData("image/jpeg", false)]
+        public void DadoNomeArquivo_QuandoEhImagemTiff_EntaoRetornaResultadoEsperado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhImagemTiff();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("10", "10")]
+        [InlineData("", "0")]
+        [InlineData(null, "0")]
+        public void DadoString_QuandoObterValorOuZero_EntaoRetornaValorOuZeroSeVazio(string? valor, string esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.ObterValorOuZero();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("Atenção", "Atencao")]
+        [InlineData("Árvore", "Arvore")]
+        [InlineData("João", "Joao")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoStringComAcentos_QuandoRemoverAcentuacao_EntaoRetornaStringLimpa(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.RemoverAcentuacao();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("Atenção", "atencao")]
+        [InlineData("Árvore", "arvore")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoStringComAcentos_QuandoRemoverAcentuacaoFormatarMinusculo_EntaoRetornaStringLimpaEMinuscula(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.RemoverAcentuacaoFormatarMinusculo();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("arquivo.pdf", ".pdf")]
+        [InlineData("foto.jpg", ".jpg")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoNomeArquivo_QuandoObterExtensao_EntaoRetornaAExtensao(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.ObterExtensao();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("12,34", false)] // É numérico com casas (falha na negativa = false)
+        [InlineData("12.34", true)]  // Formato inválido pelo regex estrito
+        [InlineData("abc", true)]    // Formato inválido
+        [InlineData("", true)]
+        public void DadoValor_QuandoNaoEhNumericoComCasasDecimais_EntaoValidaRegex(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.NaoEhNumericoComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("12.34", "12,34")]
+        [InlineData("12,34", "12,34")]
+        [InlineData("abc", "abc")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoValor_QuandoTratarLiteralComoDecimalComCasasDecimais_EntaoRetornaFormatado(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.TratarLiteralComoDecimalComCasasDecimais();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("[199?]", 1990)]
+        [InlineData("[19--]", 1900)]
+        [InlineData("2026", 2026)]
+        [InlineData("", 0)]
+        [InlineData(null, 0)]
+        public void DadoAnoComMascara_QuandoObterAnoNumerico_EntaoRetornaInteiroConvertido(string? valor, int esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.ObterAnoNumerico();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("[19--]", true)]
+        [InlineData("1990", false)]
+        public void DadoAno_QuandoContemDecadaOuSeculoCertoOuPossivel_EntaoRetornaResultado(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.ContemDecadaOuSeculoCertoOuPossivel();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("[19--]", true)]
+        [InlineData("[199-?]", true)]
+        [InlineData("[1999]", true)]
+        [InlineData("1999", true)]
+        [InlineData("abcd", false)]
+        public void DadoAno_QuandoEhAnoConformeFormatoABNT_EntaoValidaPeloRegex(string valor, bool esperado)
+        {
+            // Arrange & Act
+            var resultado = valor.EhAnoConformeFormatoABNT();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("111.222.333-44", "11122233344")]
+        [InlineData("123456", "123456")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoCpfComMascara_QuandoRemoverMascaraCPF_EntaoRetornaSomenteNumeros(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.RemoverMascaraCPF();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+
+        [Theory]
+        [InlineData("  Texto  ", "Texto")]
+        [InlineData("Texto", "Texto")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void DadoString_QuandoRemoverEspacos_EntaoRetornaTrimmed(string? valor, string? esperado)
+        {
+            // Arrange & Act
+            var resultado = valor!.RemoverEspacos();
+
+            // Assert
+            resultado.Should().Be(esperado);
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoArteGraficaControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoArteGraficaControllerTestes.cs
@@ -1,0 +1,149 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoArteGraficaControllerTestes
+    {
+        private readonly Mock<IServicoAcervoArteGrafica> servicoAcervoArteGraficaMock;
+        private readonly AcervoArteGraficaController sut;
+
+        public AcervoArteGraficaControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoArteGraficaMock = mocker.GetMock<IServicoAcervoArteGrafica>();
+
+            sut = mocker.CreateInstance<AcervoArteGraficaController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervoArteGraficaCadastroValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoArteGraficaCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcervoArteGraficaMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoArteGraficaMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoArteGraficaAlteracaoValida_QuandoAlterar_EntaoRetornaOkComAcervoAlterado()
+        {
+            // Arrange
+            var dto = GerarAcervoArteGraficaAlteracaoDTO();
+            var dtoRetorno = GerarAcervoArteGraficaDTO();
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcervoArteGraficaMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoArteGraficaMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoObterPorId_EntaoRetornaOkComAcervoEncontrado()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarAcervoArteGraficaDTO();
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAcervoArteGraficaMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoArteGraficaMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcervoArteGraficaMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcervoArteGraficaMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcervoArteGraficaMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoArteGraficaCadastroDTO GerarAcervoArteGraficaCadastroDTO() => new Faker<AcervoArteGraficaCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .RuleFor(x => x.Localizacao, f => f.Address.FullAddress())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.CopiaDigital, f => f.Random.Bool())
+            .RuleFor(x => x.PermiteUsoImagem, f => f.Random.Bool())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.CromiaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Tecnica, f => f.Lorem.Word())
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Long(1, 50))
+            .Generate();
+
+        private static AcervoArteGraficaAlteracaoDTO GerarAcervoArteGraficaAlteracaoDTO() => new Faker<AcervoArteGraficaAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.CromiaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Long(1, 50))
+            .Generate();
+
+        private static AcervoArteGraficaDTO GerarAcervoArteGraficaDTO() => new Faker<AcervoArteGraficaDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Localizacao, f => f.Address.FullAddress())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoAudiovisualControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoAudiovisualControllerTestes.cs
@@ -1,0 +1,146 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoAudiovisualControllerTestes
+    {
+        private readonly Mock<IServicoAcervoAudiovisual> servicoAcervoAudiovisualMock;
+        private readonly AcervoAudiovisualController sut;
+
+        public AcervoAudiovisualControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoAudiovisualMock = mocker.GetMock<IServicoAcervoAudiovisual>();
+
+            sut = mocker.CreateInstance<AcervoAudiovisualController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervoAudiovisualCadastroValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoAudiovisualCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcervoAudiovisualMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoAudiovisualMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoAudiovisualAlteracaoValida_QuandoAlterar_EntaoRetornaOkComAcervoAlterado()
+        {
+            // Arrange
+            var dto = GerarAcervoAudiovisualAlteracaoDTO();
+            var dtoRetorno = GerarAcervoAudiovisualDTO();
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcervoAudiovisualMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoAudiovisualMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoObterPorId_EntaoRetornaOkComAcervoEncontrado()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarAcervoAudiovisualDTO();
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAcervoAudiovisualMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoAudiovisualMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcervoAudiovisualMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcervoAudiovisualMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcervoAudiovisualMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoAudiovisualCadastroDTO GerarAcervoAudiovisualCadastroDTO() => new Faker<AcervoAudiovisualCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .RuleFor(x => x.Localizacao, f => f.Address.FullAddress())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Copia, f => f.Lorem.Word())
+            .RuleFor(x => x.PermiteUsoImagem, f => f.Random.Bool())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Duracao, f => $"{f.Random.Int(0, 2):D2}:{f.Random.Int(0, 59):D2}:{f.Random.Int(0, 59):D2}")
+            .RuleFor(x => x.CromiaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.TamanhoArquivo, f => $"{f.Random.Int(1, 500)} MB")
+            .RuleFor(x => x.Acessibilidade, f => f.Lorem.Word())
+            .RuleFor(x => x.Disponibilizacao, f => f.Lorem.Sentence())
+            .Generate();
+
+        private static AcervoAudiovisualAlteracaoDTO GerarAcervoAudiovisualAlteracaoDTO() => new Faker<AcervoAudiovisualAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .Generate();
+
+        private static AcervoAudiovisualDTO GerarAcervoAudiovisualDTO() => new Faker<AcervoAudiovisualDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Duracao, f => $"{f.Random.Int(0, 2):D2}:{f.Random.Int(0, 59):D2}:{f.Random.Int(0, 59):D2}")
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoBibliograficoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoBibliograficoControllerTestes.cs
@@ -1,0 +1,179 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Enumerados;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoBibliograficoControllerTestes
+    {
+        private readonly Mock<IServicoAcervoBibliografico> servicoAcervoBibliograficoMock;
+        private readonly AcervoBibliograficoController sut;
+
+        public AcervoBibliograficoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoBibliograficoMock = mocker.GetMock<IServicoAcervoBibliografico>();
+
+            sut = mocker.CreateInstance<AcervoBibliograficoController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervoBibliograficoCadastroValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoBibliograficoMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcervoBibliograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoBibliograficoMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoBibliograficoAlteracaoValida_QuandoAlterar_EntaoRetornaOkComAcervoAlterado()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoAlteracaoDTO();
+            var dtoRetorno = GerarAcervoBibliograficoDTO();
+
+            servicoAcervoBibliograficoMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcervoBibliograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoBibliograficoMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoObterPorId_EntaoRetornaOkComAcervoEncontrado()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarAcervoBibliograficoDTO();
+
+            servicoAcervoBibliograficoMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAcervoBibliograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoBibliograficoMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcervoBibliograficoMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcervoBibliograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcervoBibliograficoMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoBibliograficoCadastroDTO GerarAcervoBibliograficoCadastroDTO() => new Faker<AcervoBibliograficoCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.CodigoNovo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.SubTitulo, f => f.Lorem.Sentence(2))
+            .RuleFor(x => x.DataAcervo, f => f.Date.Past().ToString("dd/MM/yyyy"))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .RuleFor(x => x.MaterialId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.EditoraId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.AssuntosIds, f => new[] { f.Random.Long(1, 10), f.Random.Long(11, 20) })
+            .RuleFor(x => x.Edicao, f => f.Random.Int(1, 10).ToString())
+            .RuleFor(x => x.NumeroPagina, f => f.Random.Int(50, 1000))
+            .RuleFor(x => x.Largura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Altura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.SerieColecaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Volume, f => f.Random.Int(1, 5).ToString())
+            .RuleFor(x => x.IdiomaId, f => f.Random.Long(1, 10))
+            .RuleFor(x => x.LocalizacaoCDD, f => f.Random.AlphaNumeric(20))
+            .RuleFor(x => x.LocalizacaoPHA, f => f.Random.AlphaNumeric(20))
+            .RuleFor(x => x.NotasGerais, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Isbn, f => f.Commerce.Ean13())
+            .RuleFor(x => x.SituacaoSaldo, f => f.PickRandom<SituacaoSaldo>())
+            .RuleFor(x => x.CreditosAutoresIds, f => new[] { f.Random.Long(1, 10) })
+            .RuleFor(x => x.CoAutores, f => GerarListaCoAutorDTO().ToArray())
+            .Generate();
+
+        private static AcervoBibliograficoAlteracaoDTO GerarAcervoBibliograficoAlteracaoDTO() => new Faker<AcervoBibliograficoAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.MaterialId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.IdiomaId, f => f.Random.Long(1, 10))
+            .RuleFor(x => x.LocalizacaoCDD, f => f.Random.AlphaNumeric(20))
+            .Generate();
+
+        private static AcervoBibliograficoDTO GerarAcervoBibliograficoDTO() => new Faker<AcervoBibliograficoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.SubTitulo, f => f.Lorem.Sentence(2))
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.MaterialId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.EditoraId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.AssuntosIds, f => new[] { f.Random.Long(1, 10) })
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Edicao, f => f.Random.Int(1, 10).ToString())
+            .RuleFor(x => x.NumeroPagina, f => f.Random.Int(50, 1000))
+            .RuleFor(x => x.Largura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Altura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Volume, f => f.Random.Int(1, 5).ToString())
+            .RuleFor(x => x.IdiomaId, f => f.Random.Long(1, 10))
+            .RuleFor(x => x.LocalizacaoCDD, f => f.Random.AlphaNumeric(20))
+            .RuleFor(x => x.Isbn, f => f.Commerce.Ean13())
+            .RuleFor(x => x.CreditosAutoresIds, f => new[] { f.Random.Long(1, 10) })
+            .RuleFor(x => x.CoAutores, f => GerarListaCoAutorDTO().ToArray())
+            .RuleFor(x => x.SituacaoSaldo, f => f.PickRandom<SituacaoSaldo>())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .Generate();
+
+        private static System.Collections.Generic.List<CoAutorDTO> GerarListaCoAutorDTO() => new Faker<CoAutorDTO>("pt_BR")
+            .RuleFor(x => x.CreditoAutorId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.TipoAutoria, f => f.Lorem.Word())
+            .RuleFor(x => x.CreditoAutorNome, f => f.Name.FullName())
+            .Generate(2)
+            .ToList();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoEmprestimoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoEmprestimoControllerTestes.cs
@@ -1,0 +1,98 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoEmprestimoControllerTestes
+    {
+        private readonly Mock<IServicoAcervoEmprestimo> servicoAcervoEmprestimoMock;
+        private readonly AcervoEmprestimoController sut;
+
+        public AcervoEmprestimoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoEmprestimoMock = mocker.GetMock<IServicoAcervoEmprestimo>();
+
+            sut = mocker.CreateInstance<AcervoEmprestimoController>();
+        }
+
+        [Fact]
+        public async Task DadoProrrogacaoValida_QuandoProrrogarEmprestimo_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var dto = GerarAcervoEmprestimoProrrogacaoDTO();
+            var prorrogadoComSucesso = true;
+
+            servicoAcervoEmprestimoMock
+                .Setup(s => s.ProrrogarEmprestimo(dto))
+                .ReturnsAsync(prorrogadoComSucesso);
+
+            // Act
+            var resultado = await sut.ProrrogarEmprestimo(dto, servicoAcervoEmprestimoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(prorrogadoComSucesso);
+            servicoAcervoEmprestimoMock.Verify(s => s.ProrrogarEmprestimo(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRequisicaoValida_QuandoObterSituacoesEmprestimo_EntaoRetornaOkComListaDeSituacoes()
+        {
+            // Arrange
+            var listaSituacoes = GerarListaSituacaoItemDTO(3);
+
+            servicoAcervoEmprestimoMock
+                .Setup(s => s.ObterSituacoesEmprestimo())
+                .ReturnsAsync(listaSituacoes);
+
+            // Act
+            var resultado = await sut.ObterSituacoesEmprestimo(servicoAcervoEmprestimoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(listaSituacoes);
+            servicoAcervoEmprestimoMock.Verify(s => s.ObterSituacoesEmprestimo(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoItemIdValido_QuandoDevolverItemEmprestado_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = new Faker().Random.Long(1, 1000);
+            var devolvidoComSucesso = true;
+
+            servicoAcervoEmprestimoMock
+                .Setup(s => s.DevolverItemEmprestado(acervoSolicitacaoItemId))
+                .ReturnsAsync(devolvidoComSucesso);
+
+            // Act
+            var resultado = await sut.DevolverItemEmprestado(acervoSolicitacaoItemId, servicoAcervoEmprestimoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(devolvidoComSucesso);
+            servicoAcervoEmprestimoMock.Verify(s => s.DevolverItemEmprestado(acervoSolicitacaoItemId), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoEmprestimoProrrogacaoDTO GerarAcervoEmprestimoProrrogacaoDTO() => new Faker<AcervoEmprestimoProrrogacaoDTO>("pt_BR")
+            .RuleFor(x => x.AcervoSolicitacaoItemId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.DataDevolucao, f => f.Date.Future())
+            .Generate();
+
+        private static List<SituacaoItemDTO> GerarListaSituacaoItemDTO(int quantidade) => new Faker<SituacaoItemDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .Generate(quantidade)
+            .ToList();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoFotograficoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoFotograficoControllerTestes.cs
@@ -1,0 +1,158 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoFotograficoControllerTestes
+    {
+        private readonly Mock<IServicoAcervoFotografico> servicoAcervoFotograficoMock;
+        private readonly AcervoFotograficoController sut;
+
+        public AcervoFotograficoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoFotograficoMock = mocker.GetMock<IServicoAcervoFotografico>();
+
+            sut = mocker.CreateInstance<AcervoFotograficoController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervoFotograficoCadastroValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoFotograficoCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcervoFotograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoFotograficoMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoFotograficoAlteracaoValida_QuandoAlterar_EntaoRetornaOkComAcervoAlterado()
+        {
+            // Arrange
+            var dto = GerarAcervoFotograficoAlteracaoDTO();
+            var dtoRetorno = GerarAcervoFotograficoDTO();
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcervoFotograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoFotograficoMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoObterPorId_EntaoRetornaOkComAcervoEncontrado()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarAcervoFotograficoDTO();
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAcervoFotograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoFotograficoMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcervoFotograficoMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcervoFotograficoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcervoFotograficoMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoFotograficoCadastroDTO GerarAcervoFotograficoCadastroDTO() => new Faker<AcervoFotograficoCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .RuleFor(x => x.Localizacao, f => f.Address.FullAddress())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.CopiaDigital, f => f.Random.Bool())
+            .RuleFor(x => x.PermiteUsoImagem, f => f.Random.Bool())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Int(1, 50))
+            .RuleFor(x => x.Largura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Altura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.FormatoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.TamanhoArquivo, f => $"{f.Random.Int(1, 500)} MB")
+            .RuleFor(x => x.CromiaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Resolucao, f => $"{f.Random.Int(72, 300)} DPI")
+            .Generate();
+
+        private static AcervoFotograficoAlteracaoDTO GerarAcervoFotograficoAlteracaoDTO() => new Faker<AcervoFotograficoAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Int(1, 50))
+            .RuleFor(x => x.SuporteId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.FormatoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.TamanhoArquivo, f => $"{f.Random.Int(1, 500)} MB")
+            .RuleFor(x => x.CromiaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Resolucao, f => $"{f.Random.Int(72, 300)} DPI")
+            .Generate();
+
+        private static AcervoFotograficoDTO GerarAcervoFotograficoDTO() => new Faker<AcervoFotograficoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Localizacao, f => f.Address.FullAddress())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.TamanhoArquivo, f => $"{f.Random.Int(1, 500)} MB")
+            .RuleFor(x => x.Resolucao, f => $"{f.Random.Int(72, 300)} DPI")
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoSolicitacaoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoSolicitacaoControllerTestes.cs
@@ -1,0 +1,439 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoSolicitacaoControllerTestes
+    {
+        private readonly Mock<IServicoAcervoSolicitacao> servicoAcervoSolicitacaoMock;
+        private readonly AcervoSolicitacaoController sut;
+
+        public AcervoSolicitacaoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoSolicitacaoMock = mocker.GetMock<IServicoAcervoSolicitacao>();
+
+            sut = mocker.CreateInstance<AcervoSolicitacaoController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervosIdsValidos_QuandoObterItensAcervoPorAcervosIdsViaConsultaAcervoPortal_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var faker = new Faker();
+            var acervosIds = new long[] { faker.Random.Long(1, 100), faker.Random.Long(1, 100), faker.Random.Long(1, 100) };
+            var retornoMock = GerarAcervoTipoTituloAcervoIdCreditosAutoresDTO(3);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterItensAcervoPorAcervosIds(acervosIds))
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterItensAcervoPorAcervosIdsViaConsultaAcervoPortal(acervosIds, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterItensAcervoPorAcervosIds(acervosIds), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoDeCadastroValido_QuandoCadastrarAcervoSolicitacaoViaPortal_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoSolicitacaoItemCadastroDTO(2);
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.CadastrarAcervoSolicitacaoViaPortal(dto, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoSolicitacaoMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdExistente_QuandoObterSolicitacaoPorId_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+            var retornoMock = new AcervoSolicitacaoRetornoCadastroDTO { PodeCancelarSolicitacao = true, Itens = new List<AcervoSolicitacaoItemRetornoCadastroDTO>() };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterPorId(acervoSolicitacaoId))
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterSolicitacaoPorId(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterPorId(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdExistente_QuandoObterMinhaSolicitacaoPorId_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+            var retornoMock = new AcervoSolicitacaoRetornoCadastroDTO { PodeCancelarSolicitacao = false, Itens = new List<AcervoSolicitacaoItemRetornoCadastroDTO>() };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterMinhaSolicitacaoPorId(acervoSolicitacaoId))
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterMinhaSolicitacaoPorId(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterMinhaSolicitacaoPorId(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdExistente_QuandoExcluirAtendimentoLogicamente_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.Excluir(acervoSolicitacaoId))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.ExcluirAtendimentoLogicamente(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.Excluir(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoUsuarioAutenticado_QuandoObterMinhasSolicitacoes_EntaoRetornaOkComListaPaginada()
+        {
+            // Arrange
+            var retornoMock = new PaginacaoResultadoDTO<MinhaSolicitacaoDTO>
+            {
+                TotalPaginas = 1,
+                TotalRegistros = 10,
+                Items = []
+            };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterMinhasSolicitacoes())
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterMinhasSolicitacoes(servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterMinhasSolicitacoes(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRequisicaoValida_QuandoObterSituacoesAtendimentosItem_EntaoRetornaOkComLista()
+        {
+            // Arrange
+            var retornoMock = new List<SituacaoItemDTO> { new SituacaoItemDTO { Id = 1, Nome = "Pendente" } };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterSituacoesAtendimentosItem())
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterSituacoesAtendimentosItem(servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterSituacoesAtendimentosItem(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoFiltroPreenchido_QuandoObterAtendimentoSolicitacoesPorFiltro_EntaoRetornaOkComResultado()
+        {
+            // Arrange
+            var filtro = GerarFiltroSolicitacaoDTO();
+            var retornoMock = new PaginacaoResultadoDTO<SolicitacaoDTO> { TotalRegistros = 5, Items = new List<SolicitacaoDTO>() };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterAtendimentoSolicitacoesPorFiltro(filtro))
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterAtendimentoSolicitacoesPorFiltro(filtro, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterAtendimentoSolicitacoesPorFiltro(filtro), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdSolicitacaoExistente_QuandoObterDetalhesParaAtendimentoSolicitadoesPorId_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+            var retornoMock = new AcervoSolicitacaoDetalheDTO { Id = acervoSolicitacaoId, PodeCancelar = true };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterDetalhesParaAtendimentoSolicitadoesPorId(acervoSolicitacaoId))
+                .ReturnsAsync(retornoMock);
+
+            // Act
+            var resultado = await sut.ObterDetalhesParaAtendimentoSolicitadoesPorId(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterDetalhesParaAtendimentoSolicitadoesPorId(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public void DadoRequisicaoValida_QuandoObterTiposDeAtendimentos_EntaoRetornaOkComLista()
+        {
+            // Arrange
+            var retornoMock = new List<IdNomeDTO> { new IdNomeDTO { Id = 1, Nome = "Presencial" } };
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ObterTiposDeAtendimentos())
+                .Returns(retornoMock);
+
+            // Act
+            var resultado = sut.ObterTiposDeAtendimentos(servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoMock);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ObterTiposDeAtendimentos(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoConfirmacaoValido_QuandoConfirmarAtendimento_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var dto = GerarAcervoSolicitacaoConfirmarDto();
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.ConfirmarAtendimento(dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.ConfirmarAtendimento(dto, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.ConfirmarAtendimento(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdSolicitacaoExistente_QuandoFinalizarAtendimento_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.FinalizarAtendimento(acervoSolicitacaoId))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.FinalizarAtendimento(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.FinalizarAtendimento(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdItemExistente_QuandoFinalizarAtendimentoItem_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = new Faker().Random.Long(1, 100);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.FinalizarAtendimentoItem(acervoSolicitacaoItemId))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.FinalizarAtendimentoItem(acervoSolicitacaoItemId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.FinalizarAtendimentoItem(acervoSolicitacaoItemId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdSolicitacaoExistente_QuandoCancelarAtendimento_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoId = new Faker().Random.Long(1, 100);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.CancelarAtendimento(acervoSolicitacaoId))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.CancelarAtendimento(acervoSolicitacaoId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.CancelarAtendimento(acervoSolicitacaoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdItemExistente_QuandoCancelarItemAtendimento_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var acervoSolicitacaoItemId = new Faker().Random.Long(1, 100);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.CancelarItemAtendimento(acervoSolicitacaoItemId))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.CancelarItemAtendimento(acervoSolicitacaoItemId, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.CancelarItemAtendimento(acervoSolicitacaoItemId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoAlteracaoDataValido_QuandoAlterarDataVisitaDoItemAtendimento_EntaoRetornaOkComTrue()
+        {
+            // Arrange
+            var dto = GerarAlterarDataVisitaAcervoSolicitacaoItemDTO();
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.AlterarDataVisitaDoItemAtendimento(dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarDataVisitaDoItemAtendimento(dto, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAcervoSolicitacaoMock.Verify(s => s.AlterarDataVisitaDoItemAtendimento(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoInsercaoManualValido_QuandoCadastrarAcervoSolicitacaoManual_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoSolicitacaoManualDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.CadastrarAcervoSolicitacaoManual(dto, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoSolicitacaoMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoAlteracaoManualValido_QuandoAlterarAcervoSolicitacaoManual_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoSolicitacaoManualDTO();
+            var idAtualizado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoSolicitacaoMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(idAtualizado);
+
+            // Act
+            var resultado = await sut.AlterarAcervoSolicitacaoManual(dto, servicoAcervoSolicitacaoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idAtualizado);
+            servicoAcervoSolicitacaoMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoTipoTituloAcervoIdCreditosAutoresDTO[] GerarAcervoTipoTituloAcervoIdCreditosAutoresDTO(int quantidade) =>
+            [.. new Faker<AcervoTipoTituloAcervoIdCreditosAutoresDTO>("pt_BR")
+                .RuleFor(x => x.TipoAcervo, f => f.Commerce.Department())
+                .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 100))
+                .RuleFor(x => x.Titulo, f => f.Commerce.ProductName())
+                .RuleFor(x => x.SituacaoDisponibilidade, f => f.PickRandom("Disponível", "Indisponível"))
+                .RuleFor(x => x.EstaDisponivel, f => f.Random.Bool())
+                .RuleFor(x => x.TemControleDisponibilidade, f => f.Random.Bool())
+                .RuleFor(x => x.AutoresCreditos, f => f.Make(2, () => f.Name.FullName()).ToArray())
+                .RuleFor(x => x.TipoAcervoId, f => f.PickRandom<TipoAcervo>())
+                .Generate(quantidade)];
+
+        private static AcervoSolicitacaoItemCadastroDTO[] GerarAcervoSolicitacaoItemCadastroDTO(int quantidade) =>
+            [.. new Faker<AcervoSolicitacaoItemCadastroDTO>("pt_BR")
+                .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+                .RuleFor(x => x.DataVisita, f => f.Date.Future())
+                .Generate(quantidade)];
+
+        private static FiltroSolicitacaoDTO GerarFiltroSolicitacaoDTO() => new Faker<FiltroSolicitacaoDTO>("pt_BR")
+                .RuleFor(x => x.AcervoSolicitacaoId, f => f.Random.Long(1, 1000))
+                .RuleFor(x => x.TipoAcervo, f => f.PickRandom<TipoAcervo>())
+                .RuleFor(x => x.DataSolicitacaoInicio, f => f.Date.Past())
+                .RuleFor(x => x.DataSolicitacaoFim, f => f.Date.Recent())
+                .RuleFor(x => x.DataVisitaInicio, f => f.Date.Soon())
+                .RuleFor(x => x.DataVisitaFim, f => f.Date.Future())
+                .RuleFor(x => x.Responsavel, f => f.Name.FullName())
+                .RuleFor(x => x.SituacaoItem, f => f.PickRandom<SituacaoSolicitacaoItem>())
+                .RuleFor(x => x.SolicitanteRf, f => f.Random.Replace("#######"))
+                .RuleFor(x => x.SituacaoEmprestimo, f => f.PickRandom<SituacaoEmprestimo>())
+                .Generate();
+
+        private static AcervoSolicitacaoConfirmarDto GerarAcervoSolicitacaoConfirmarDto() =>
+            new Faker<AcervoSolicitacaoConfirmarDto>("pt_BR")
+                .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+                .RuleFor(x => x.ItemId, f => f.Random.Long(1, 1000))
+                .RuleFor(x => x.DataVisita, f => f.Date.Future())
+                .RuleFor(x => x.DataEmprestimo, f => f.Date.Future())
+                .RuleFor(x => x.DataDevolucao, f => f.Date.Future())
+                .RuleFor(x => x.TipoAcervo, f => f.PickRandom<TipoAcervo>())
+                .RuleFor(x => x.TipoAtendimento, f => f.PickRandom<TipoAtendimento>())
+                .Generate();
+
+        private static AlterarDataVisitaAcervoSolicitacaoItemDTO GerarAlterarDataVisitaAcervoSolicitacaoItemDTO() =>
+            new Faker<AlterarDataVisitaAcervoSolicitacaoItemDTO>("pt_BR")
+                .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+                .RuleFor(x => x.DataVisita, f => f.Date.Future())
+                .Generate();
+
+        private static AcervoSolicitacaoManualDTO GerarAcervoSolicitacaoManualDTO() => new Faker<AcervoSolicitacaoManualDTO>("pt_BR")
+                .RuleFor(x => x.Id, f => f.Random.Long(1, 100))
+                .RuleFor(x => x.UsuarioId, f => f.Random.Long(1, 500))
+                .RuleFor(x => x.DataSolicitacao, f => f.Date.Recent())
+                .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoTridimensionalControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcervoTridimensionalControllerTestes.cs
@@ -1,0 +1,147 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcervoTridimensionalControllerTestes
+    {
+        private readonly Mock<IServicoAcervoTridimensional> servicoAcervoTridimensionalMock;
+        private readonly AcervoTridimensionalController sut;
+
+        public AcervoTridimensionalControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcervoTridimensionalMock = mocker.GetMock<IServicoAcervoTridimensional>();
+
+            sut = mocker.CreateInstance<AcervoTridimensionalController>();
+        }
+
+        [Fact]
+        public async Task DadoAcervoTridimensionalCadastroValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarAcervoTridimensionalCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcervoTridimensionalMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcervoTridimensionalMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoTridimensionalAlteracaoValida_QuandoAlterar_EntaoRetornaOkComAcervoAlterado()
+        {
+            // Arrange
+            var dto = GerarAcervoTridimensionalAlteracaoDTO();
+            var dtoRetorno = GerarAcervoTridimensionalDTO();
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcervoTridimensionalMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoTridimensionalMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoObterPorId_EntaoRetornaOkComAcervoEncontrado()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarAcervoTridimensionalDTO();
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAcervoTridimensionalMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcervoTridimensionalMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcervoTridimensionalMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcervoTridimensionalMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcervoTridimensionalMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoTridimensionalCadastroDTO GerarAcervoTridimensionalCadastroDTO() => new Faker<AcervoTridimensionalCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.SituacaoAcervo, f => f.PickRandom<SituacaoAcervo>())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Int(1, 50))
+            .RuleFor(x => x.Largura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Altura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Profundidade, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Diametro, f => f.Random.Double(10, 50).ToString("N2"))
+            .Generate();
+
+        private static AcervoTridimensionalAlteracaoDTO GerarAcervoTridimensionalAlteracaoDTO() => new Faker<AcervoTridimensionalAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.ConservacaoId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Quantidade, f => f.Random.Int(1, 50))
+            .Generate();
+
+        private static AcervoTridimensionalDTO GerarAcervoTridimensionalDTO() => new Faker<AcervoTridimensionalDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Codigo, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.Procedencia, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Descricao, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.Largura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Altura, f => f.Random.Double(10, 50).ToString("N2"))
+            .RuleFor(x => x.Profundidade, f => f.Random.Double(10, 50).ToString("N2"))
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcessoDocumentoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AcessoDocumentoControllerTestes.cs
@@ -1,0 +1,151 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AcessoDocumentoControllerTestes
+    {
+        private readonly Mock<IServicoAcessoDocumento> servicoAcessoDocumentoMock;
+        private readonly AcessoDocumentoController sut;
+
+        public AcessoDocumentoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAcessoDocumentoMock = mocker.GetMock<IServicoAcessoDocumento>();
+
+            sut = mocker.CreateInstance<AcessoDocumentoController>();
+        }
+
+        [Fact]
+        public async Task DadoNomeDtoValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarNomeDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAcessoDocumentoMock
+                .Setup(s => s.Inserir(It.Is<IdNomeExcluidoDTO>(x => x.Nome == dto.Nome)))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAcessoDocumentoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAcessoDocumentoMock.Verify(s => s.Inserir(It.Is<IdNomeExcluidoDTO>(x => x.Nome == dto.Nome)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdNomeDtoValido_QuandoAlterar_EntaoRetornaOkComDtoAlterado()
+        {
+            // Arrange
+            var dto = GerarIdNomeDTO();
+            var dtoRetorno = GerarIdNomeExcluidoDTO();
+
+            servicoAcessoDocumentoMock
+                .Setup(s => s.Alterar(It.Is<IdNomeExcluidoDTO>(x => x.Id == dto.Id && x.Nome == dto.Nome)))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAcessoDocumentoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcessoDocumentoMock.Verify(s => s.Alterar(It.Is<IdNomeExcluidoDTO>(x => x.Id == dto.Id && x.Nome == dto.Nome)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaValida_QuandoObterTodos_EntaoRetornaOkComLista()
+        {
+            // Arrange
+            var listaRetorno = GerarListaIdNomeExcluidoDTO(3);
+
+            servicoAcessoDocumentoMock
+                .Setup(s => s.ObterTodos())
+                .ReturnsAsync(listaRetorno);
+
+            // Act
+            var resultado = await sut.ObterTodos(servicoAcessoDocumentoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(listaRetorno);
+            servicoAcessoDocumentoMock.Verify(s => s.ObterTodos(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdValido_QuandoObterPorId_EntaoRetornaOkComDto()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoRetorno = GerarIdNomeExcluidoDTO();
+            dtoRetorno.Id = id;
+
+            servicoAcessoDocumentoMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoRetorno);
+
+            // Act
+            // O nome do método na controller está ObterTodos com sobrecarga de long id
+            var resultado = await sut.ObterTodos(id, servicoAcessoDocumentoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoRetorno);
+            servicoAcessoDocumentoMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComResultadoBooleano()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var exclusaoSucesso = true;
+
+            servicoAcessoDocumentoMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(exclusaoSucesso);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAcessoDocumentoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoSucesso);
+            servicoAcessoDocumentoMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static NomeDTO GerarNomeDTO() => new Faker<NomeDTO>("pt_BR")
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .Generate();
+
+        private static IdNomeDTO GerarIdNomeDTO() => new Faker<IdNomeDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .Generate();
+
+        private static IdNomeExcluidoDTO GerarIdNomeExcluidoDTO() => new Faker<IdNomeExcluidoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .RuleFor(x => x.Excluido, f => f.Random.Bool())
+            .Generate();
+
+        private static List<IdNomeExcluidoDTO> GerarListaIdNomeExcluidoDTO(int quantidade) => new Faker<IdNomeExcluidoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .RuleFor(x => x.Excluido, f => f.Random.Bool())
+            .Generate(quantidade)
+            .ToList();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/ArmazenamentoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/ArmazenamentoControllerTestes.cs
@@ -1,0 +1,172 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class ArmazenamentoControllerTestes
+    {
+        private readonly Mock<IServicoUploadArquivo> servicoUploadArquivoMock;
+        private readonly Mock<IServicoDownloadArquivo> servicoDownloadArquivoMock;
+        private readonly ArmazenamentoController sut;
+
+        public ArmazenamentoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoUploadArquivoMock = mocker.GetMock<IServicoUploadArquivo>();
+            servicoDownloadArquivoMock = mocker.GetMock<IServicoDownloadArquivo>();
+
+            sut = mocker.CreateInstance<ArmazenamentoController>();
+        }
+
+        [Fact]
+        public async Task DadoArquivoValido_QuandoUploadTemp_EntaoRetornaOkComDadosDoArquivoArmazenado()
+        {
+            // Arrange
+            var fileMock = new Mock<IFormFile>();
+            var arquivoArmazenadoEsperado = GerarArquivoArmazenadoDTO();
+
+            servicoUploadArquivoMock
+                .Setup(s => s.Upload(fileMock.Object, TipoArquivo.Temp))
+                .ReturnsAsync(arquivoArmazenadoEsperado);
+
+            // Act
+            var resultado = await sut.UploadTemp(fileMock.Object, servicoUploadArquivoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(arquivoArmazenadoEsperado);
+            servicoUploadArquivoMock.Verify(s => s.Upload(fileMock.Object, TipoArquivo.Temp), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoCodigoArquivoValidoEEncontrado_QuandoDownload_EntaoRetornaFileResult()
+        {
+            // Arrange
+            var codigoArquivo = Guid.NewGuid();
+            var bytesArquivo = new byte[] { 1, 2, 3 };
+            var contentType = "application/pdf";
+            var nomeArquivo = "documento.pdf";
+
+            servicoDownloadArquivoMock
+                .Setup(s => s.Download(codigoArquivo))
+                .ReturnsAsync((bytesArquivo, contentType, nomeArquivo));
+
+            // Act
+            var resultado = await sut.Download(codigoArquivo, servicoDownloadArquivoMock.Object);
+
+            // Assert
+            var fileResult = resultado.Should().BeOfType<FileContentResult>().Subject;
+            fileResult.FileContents.Should().BeEquivalentTo(bytesArquivo);
+            fileResult.ContentType.Should().Be(contentType);
+            fileResult.FileDownloadName.Should().Be(nomeArquivo);
+            servicoDownloadArquivoMock.Verify(s => s.Download(codigoArquivo), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoCodigoArquivoNaoEncontrado_QuandoDownload_EntaoRetornaNoContent()
+        {
+            // Arrange
+            var codigoArquivo = Guid.NewGuid();
+
+            servicoDownloadArquivoMock
+                .Setup(s => s.Download(codigoArquivo))
+                .ReturnsAsync(((byte[])null!, null!, null!));
+
+            // Act
+            var resultado = await sut.Download(codigoArquivo, servicoDownloadArquivoMock.Object);
+
+            // Assert
+            resultado.Should().BeOfType<NoContentResult>();
+            servicoDownloadArquivoMock.Verify(s => s.Download(codigoArquivo), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoArquivoETipoValidos_QuandoUploadPorTipo_EntaoRetornaOkComDadosDoArquivoArmazenado()
+        {
+            // Arrange
+            var fileMock = new Mock<IFormFile>();
+            var tipoArquivo = TipoArquivo.AcervoDocumental;
+            var arquivoArmazenadoEsperado = GerarArquivoArmazenadoDTO(tipoArquivo);
+
+            servicoUploadArquivoMock
+                .Setup(s => s.Upload(fileMock.Object, tipoArquivo))
+                .ReturnsAsync(arquivoArmazenadoEsperado);
+
+            // Act
+            var resultado = await sut.UploadPorTipo(fileMock.Object, tipoArquivo, servicoUploadArquivoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(arquivoArmazenadoEsperado);
+            servicoUploadArquivoMock.Verify(s => s.Upload(fileMock.Object, tipoArquivo), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTipoAcervoComModeloEncontrado_QuandoDownloadPorTipoAcervo_EntaoRetornaFileResult()
+        {
+            // Arrange
+            var tipoAcervo = TipoAcervo.DocumentacaoTextual;
+            var bytesArquivo = new byte[] { 4, 5, 6 };
+            var contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            var nomeArquivo = "planilha_acervo_documental.xlsx";
+
+            servicoDownloadArquivoMock
+                .Setup(s => s.DownloadPorTipoAcervo(tipoAcervo))
+                .ReturnsAsync((bytesArquivo, contentType, nomeArquivo));
+
+            // Act
+            var resultado = await sut.DownloadPorTipoAcervo(tipoAcervo, servicoDownloadArquivoMock.Object);
+
+            // Assert
+            var fileResult = resultado.Should().BeOfType<FileContentResult>().Subject;
+            fileResult.FileContents.Should().BeEquivalentTo(bytesArquivo);
+            fileResult.ContentType.Should().Be(contentType);
+            fileResult.FileDownloadName.Should().Be(nomeArquivo);
+            servicoDownloadArquivoMock.Verify(s => s.DownloadPorTipoAcervo(tipoAcervo), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTipoAcervoSemModeloEncontrado_QuandoDownloadPorTipoAcervo_EntaoRetornaNoContent()
+        {
+            // Arrange
+            var tipoAcervo = TipoAcervo.Audiovisual;
+
+            servicoDownloadArquivoMock
+                .Setup(s => s.DownloadPorTipoAcervo(tipoAcervo))
+                .ReturnsAsync(((byte[])null!, null!, null!));
+
+            // Act
+            var resultado = await sut.DownloadPorTipoAcervo(tipoAcervo, servicoDownloadArquivoMock.Object);
+
+            // Assert
+            resultado.Should().BeOfType<NoContentResult>();
+            servicoDownloadArquivoMock.Verify(s => s.DownloadPorTipoAcervo(tipoAcervo), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static ArquivoArmazenadoDTO GerarArquivoArmazenadoDTO(TipoArquivo tipoArquivo = TipoArquivo.Temp)
+        {
+            var faker = new Faker();
+            return new ArquivoArmazenadoDTO(
+                path: faker.System.FilePath(),
+                codigo: Guid.NewGuid(),
+                nome: faker.System.FileName(),
+                contentType: faker.System.MimeType(),
+                tipoArquivo: tipoArquivo
+            )
+            {
+                Id = faker.Random.Long(1, 1000)
+            };
+        }
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AssuntoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AssuntoControllerTestes.cs
@@ -1,0 +1,178 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AssuntoControllerTestes
+    {
+        private readonly Mock<IServicoAssunto> servicoAssuntoMock;
+        private readonly AssuntoController sut;
+
+        public AssuntoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoAssuntoMock = mocker.GetMock<IServicoAssunto>();
+
+            sut = mocker.CreateInstance<AssuntoController>();
+        }
+
+        [Fact]
+        public async Task DadoNomeDtoValido_QuandoInserir_EntaoRetornaOkComId()
+        {
+            // Arrange
+            var dto = GerarNomeDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoAssuntoMock
+                .Setup(s => s.Inserir(It.Is<IdNomeExcluidoAuditavelDTO>(x => x.Nome == dto.Nome)))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoAssuntoMock.Verify(s => s.Inserir(It.Is<IdNomeExcluidoAuditavelDTO>(x => x.Nome == dto.Nome)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdNomeDtoValido_QuandoAlterar_EntaoRetornaOkComDtoAlterado()
+        {
+            // Arrange
+            var dto = GerarIdNomeDTO();
+            var dtoAlterado = GerarIdNomeExcluidoAuditavelDTO().Generate();
+
+            servicoAssuntoMock
+                .Setup(s => s.Alterar(It.Is<IdNomeExcluidoAuditavelDTO>(x => x.Id == dto.Id && x.Nome == dto.Nome)))
+                .ReturnsAsync(dtoAlterado);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoAlterado);
+            servicoAssuntoMock.Verify(s => s.Alterar(It.Is<IdNomeExcluidoAuditavelDTO>(x => x.Id == dto.Id && x.Nome == dto.Nome)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoNome_QuandoObterTodosOuPorNome_EntaoRetornaOkComResultadoPaginado()
+        {
+            // Arrange
+            var nomePesquisa = new Faker().Commerce.Department();
+            var resultadoPaginado = GerarPaginacaoResultadoDTO();
+
+            servicoAssuntoMock
+                .Setup(s => s.ObterPaginado(nomePesquisa))
+                .ReturnsAsync(resultadoPaginado);
+
+            // Act
+            var resultado = await sut.ObterTodosOuPorNome(nomePesquisa, servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(resultadoPaginado);
+            servicoAssuntoMock.Verify(s => s.ObterPaginado(nomePesquisa), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoChamadaValida_QuandoObterTodos_EntaoRetornaOkComListaResumida()
+        {
+            // Arrange
+            var listaCompleta = GerarListaIdNomeExcluidoAuditavelDTO(3);
+            var listaResumidaEsperada = listaCompleta.Select(s => new IdNomeDTO { Id = s.Id, Nome = s.Nome }).ToList();
+
+            servicoAssuntoMock
+                .Setup(s => s.ObterTodos())
+                .ReturnsAsync(listaCompleta);
+
+            // Act
+            var resultado = await sut.ObterTodos(servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(listaResumidaEsperada);
+            servicoAssuntoMock.Verify(s => s.ObterTodos(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdValido_QuandoObterPorId_EntaoRetornaOkComDto()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+            var dtoEsperado = GerarIdNomeExcluidoAuditavelDTO().Generate();
+            dtoEsperado.Id = id;
+
+            servicoAssuntoMock
+                .Setup(s => s.ObterPorId(id))
+                .ReturnsAsync(dtoEsperado);
+
+            // Act
+            var resultado = await sut.ObterPorId(id, servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dtoEsperado);
+            servicoAssuntoMock.Verify(s => s.ObterPorId(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdValido_QuandoExclusaoLogica_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var id = new Faker().Random.Long(1, 1000);
+
+            servicoAssuntoMock
+                .Setup(s => s.Excluir(id))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.ExclusaoLogica(id, servicoAssuntoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoAssuntoMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static NomeDTO GerarNomeDTO() => new Faker<NomeDTO>("pt_BR")
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .Generate();
+
+        private static IdNomeDTO GerarIdNomeDTO() => new Faker<IdNomeDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .Generate();
+
+        private static Faker<IdNomeExcluidoAuditavelDTO> GerarIdNomeExcluidoAuditavelDTO() => new Faker<IdNomeExcluidoAuditavelDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Nome, f => f.Commerce.Department())
+            .RuleFor(x => x.Excluido, f => f.Random.Bool())
+            .RuleFor(x => x.AlteradoEm, f => f.Date.Recent())
+            .RuleFor(x => x.AlteradoPor, f => f.Name.FullName())
+            .RuleFor(x => x.AlteradoLogin, f => f.Internet.UserName())
+            .RuleFor(x => x.CriadoEm, f => f.Date.Past())
+            .RuleFor(x => x.CriadoPor, f => f.Name.FullName())
+            .RuleFor(x => x.CriadoLogin, f => f.Internet.UserName())
+            ;
+
+        private static List<IdNomeExcluidoAuditavelDTO> GerarListaIdNomeExcluidoAuditavelDTO(int quantidade) =>
+            GerarIdNomeExcluidoAuditavelDTO().Generate(quantidade).ToList();
+
+        private static PaginacaoResultadoDTO<IdNomeExcluidoAuditavelDTO> GerarPaginacaoResultadoDTO() => new Faker<PaginacaoResultadoDTO<IdNomeExcluidoAuditavelDTO>>("pt_BR")
+            .RuleFor(x => x.TotalPaginas, f => f.Random.Int(1, 10))
+            .RuleFor(x => x.TotalRegistros, f => f.Random.Int(10, 100))
+            .RuleFor(x => x.Items, GerarListaIdNomeExcluidoAuditavelDTO(5))
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AutenticacaoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/AutenticacaoControllerTestes.cs
@@ -1,0 +1,110 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class AutenticacaoControllerTestes
+    {
+        private readonly Mock<IServicoUsuario> servicoUsuarioMock;
+        private readonly AutenticacaoController sut;
+
+        public AutenticacaoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoUsuarioMock = mocker.GetMock<IServicoUsuario>();
+
+            sut = mocker.CreateInstance<AutenticacaoController>();
+        }
+
+        [Fact]
+        public async Task DadoAutenticacaoDtoValido_QuandoAutenticar_EntaoRetornaOkComRetornoPerfilUsuarioDto()
+        {
+            // Arrange
+            var dto = GerarAutenticacaoDTO();
+            var retornoEsperado = GerarRetornoPerfilUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.Autenticar(dto.Login, dto.Senha))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await sut.Autenticar(dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoEsperado);
+            servicoUsuarioMock.Verify(s => s.Autenticar(dto.Login, dto.Senha), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTokenValido_QuandoRevalidar_EntaoRetornaOkComRetornoPerfilUsuarioDto()
+        {
+            // Arrange
+            var dto = GerarAutenticacaoRevalidarDTO();
+            var retornoEsperado = GerarRetornoPerfilUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.RevalidarToken(dto.Token))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await sut.Revalidar(dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoEsperado);
+            servicoUsuarioMock.Verify(s => s.RevalidarToken(dto.Token), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoPerfilUsuarioIdValido_QuandoAtualizarPerfil_EntaoRetornaOkComRetornoPerfilUsuarioDto()
+        {
+            // Arrange
+            var perfilUsuarioId = Guid.NewGuid();
+            var retornoEsperado = GerarRetornoPerfilUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.AtualizarPerfil(perfilUsuarioId))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await sut.AtualizarPerfil(perfilUsuarioId, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoEsperado);
+            servicoUsuarioMock.Verify(s => s.AtualizarPerfil(perfilUsuarioId), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AutenticacaoDTO GerarAutenticacaoDTO() => new Faker<AutenticacaoDTO>("pt_BR")
+            .RuleFor(x => x.Login, f => f.Internet.UserName())
+            .RuleFor(x => x.Senha, f => f.Internet.Password(8))
+            .Generate();
+
+        private static AutenticacaoRevalidarDTO GerarAutenticacaoRevalidarDTO() => new Faker<AutenticacaoRevalidarDTO>("pt_BR")
+            .RuleFor(x => x.Token, f => f.Random.AlphaNumeric(100))
+            .Generate();
+
+        private static RetornoPerfilUsuarioDTO GerarRetornoPerfilUsuarioDTO() => new Faker<RetornoPerfilUsuarioDTO>("pt_BR")
+            .RuleFor(x => x.UsuarioNome, f => f.Name.FullName())
+            .RuleFor(x => x.UsuarioLogin, f => f.Internet.UserName())
+            .RuleFor(x => x.DataHoraExpiracao, f => f.Date.Future())
+            .RuleFor(x => x.Token, f => f.Random.AlphaNumeric(100))
+            .RuleFor(x => x.Email, f => f.Internet.Email())
+            .RuleFor(x => x.Autenticado, true)
+            .RuleFor(x => x.PerfilUsuario, f => new List<PerfilUsuarioDTO>
+            {
+                new PerfilUsuarioDTO(Guid.NewGuid(), f.Name.JobTitle())
+            })
+            .Generate();
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/EventoControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/EventoControllerTestes.cs
@@ -1,0 +1,236 @@
+﻿using Bogus;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class EventoControllerTestes
+    {
+        private readonly Mock<IServicoEvento> servicoEventoMock;
+        private readonly EventoController sut;
+
+        public EventoControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoEventoMock = mocker.GetMock<IServicoEvento>();
+
+            sut = mocker.CreateInstance<EventoController>();
+        }
+
+        [Fact]
+        public async Task DadoEventoCadastroValido_QuandoInserir_EntaoRetornaOkComIdGerado()
+        {
+            // Arrange
+            var dto = GerarEventoCadastroDTO();
+            var idGerado = new Faker().Random.Long(1, 1000);
+
+            servicoEventoMock
+                .Setup(s => s.Inserir(dto))
+                .ReturnsAsync(idGerado);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(idGerado);
+            servicoEventoMock.Verify(s => s.Inserir(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoEventoCadastroValido_QuandoAlterar_EntaoRetornaOkComEventoAlterado()
+        {
+            // Arrange
+            var dto = GerarEventoCadastroDTO();
+            var eventoAlterado = GerarEventoDTO();
+
+            servicoEventoMock
+                .Setup(s => s.Alterar(dto))
+                .ReturnsAsync(eventoAlterado);
+
+            // Act
+            var resultado = await sut.Alterar(dto, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(eventoAlterado);
+            servicoEventoMock.Verify(s => s.Alterar(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDiaMesValido_QuandoObterEventosTagPorData_EntaoRetornaOkComListaDeTags()
+        {
+            // Arrange
+            var dto = GerarDiaMesDTO();
+            var listaTags = GerarListaEventoTagDTO(3);
+
+            servicoEventoMock
+                .Setup(s => s.ObterEventosTagPorData(dto))
+                .ReturnsAsync(listaTags);
+
+            // Act
+            var resultado = await sut.ObterEventosTagPorData(dto, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(listaTags);
+            servicoEventoMock.Verify(s => s.ObterEventosTagPorData(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoEventoIdValido_QuandoExcluirLogicamente_EntaoRetornaOkComBooleano()
+        {
+            // Arrange
+            var eventoId = new Faker().Random.Long(1, 1000);
+            var exclusaoComSucesso = true;
+
+            servicoEventoMock
+                .Setup(s => s.ExcluirLogicamente(eventoId))
+                .ReturnsAsync(exclusaoComSucesso);
+
+            // Act
+            var resultado = await sut.ExcluirLogicamente(eventoId, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(exclusaoComSucesso);
+            servicoEventoMock.Verify(s => s.ExcluirLogicamente(eventoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoEventoIdValido_QuandoObterEventoPorId_EntaoRetornaOkComDadosDoEvento()
+        {
+            // Arrange
+            var eventoId = new Faker().Random.Int(1, 1000);
+            var eventoDto = GerarEventoDTO();
+
+            servicoEventoMock
+                .Setup(s => s.ObterEventoPorId(eventoId))
+                .ReturnsAsync(eventoDto);
+
+            // Act
+            var resultado = await sut.ObterEventoPorId(eventoId, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(eventoDto);
+            servicoEventoMock.Verify(s => s.ObterEventoPorId(eventoId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoMesValido_QuandoObterCalendarioDeEventosPorMes_EntaoRetornaOkComCalendario()
+        {
+            // Arrange
+            var mes = new Faker().Random.Int(1, 12);
+            var calendarioEsperado = GerarCalendarioEventoDTO();
+
+            servicoEventoMock
+                .Setup(s => s.ObterCalendarioDeEventosPorMes(mes, It.IsAny<int>()))
+                .ReturnsAsync(calendarioEsperado);
+
+            // Act
+            var resultado = await sut.ObterCalendarioDeEventosPorMes(mes, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(calendarioEsperado);
+            servicoEventoMock.Verify(s => s.ObterCalendarioDeEventosPorMes(mes, It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDiaMesValido_QuandoObterDetalhesDoDiaPorDiaMes_EntaoRetornaOkComListaDeDetalhes()
+        {
+            // Arrange
+            var dto = GerarDiaMesDTO();
+            var detalhesEsperados = GerarListaEventoDetalheDTO(2);
+
+            servicoEventoMock
+                .Setup(s => s.ObterDetalhesDoDiaPorDiaMes(dto))
+                .ReturnsAsync(detalhesEsperados);
+
+            // Act
+            var resultado = await sut.ObterDetalhesDoDiaPorDiaMes(dto, servicoEventoMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(detalhesEsperados);
+            servicoEventoMock.Verify(s => s.ObterDetalhesDoDiaPorDiaMes(dto), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static EventoCadastroDTO GerarEventoCadastroDTO() => new Faker<EventoCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Dia, f => f.Random.Int(1, 28)) // Fixado até 28 para evitar exception em meses como Fevereiro
+            .RuleFor(x => x.Mes, f => f.Random.Int(1, 12))
+            .RuleFor(x => x.Ano, f => f.Date.Future().Year)
+            .RuleFor(x => x.Hora, f => f.Random.Int(0, 23))
+            .RuleFor(x => x.Minuto, f => f.Random.Int(0, 59))
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Tipo, f => f.PickRandom<TipoEvento>())
+            .RuleFor(x => x.Descricao, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Justificativa, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.AcervoSolicitacaoItemId, f => f.Random.Long(1, 1000))
+            .Generate();
+
+        private static EventoDTO GerarEventoDTO() => new Faker<EventoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Tipo, f => f.PickRandom<TipoEvento>())
+            .RuleFor(x => x.Descricao, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Justificativa, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.AcervoSolicitacaoItemId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Data, f => f.Date.Future())
+            .Generate();
+
+        private static DiaMesDTO GerarDiaMesDTO() => new Faker<DiaMesDTO>("pt_BR")
+            .RuleFor(x => x.Dia, f => f.Random.Int(1, 28))
+            .RuleFor(x => x.Mes, f => f.Random.Int(1, 12))
+            .RuleFor(x => x.Ano, f => f.Date.Future().Year)
+            .RuleFor(x => x.Hora, f => f.Random.Int(0, 23))
+            .RuleFor(x => x.Minuto, f => f.Random.Int(0, 59))
+            .Generate();
+
+        private static List<EventoTagDTO> GerarListaEventoTagDTO(int quantidade) => new Faker<EventoTagDTO>("pt_BR")
+            .RuleFor(x => x.TipoId, f => f.PickRandom<TipoEvento>())
+            .RuleFor(x => x.Tipo, f => f.Lorem.Word())
+            .Generate(quantidade);
+
+        private static CalendarioEventoDTO GerarCalendarioEventoDTO()
+        {
+            var dias = new Faker<DiaDTO>("pt_BR")
+                .RuleFor(x => x.Dia, f => f.Random.Int(1, 28))
+                .RuleFor(x => x.DayOfWeek, f => f.Random.Int(0, 6))
+                .RuleFor(x => x.Desabilitado, f => f.Random.Bool())
+                .RuleFor(x => x.EventosTag, f => GerarListaEventoTagDTO(2))
+                .Generate(7);
+
+            var semanas = new Faker<SemanaDTO>("pt_BR")
+                .RuleFor(x => x.Numero, f => f.Random.Int(1, 5))
+                .RuleFor(x => x.Dias, dias)
+                .Generate(4);
+
+            return new CalendarioEventoDTO { Semanas = semanas };
+        }
+
+        private static List<EventoDetalheDTO> GerarListaEventoDetalheDTO(int quantidade) => new Faker<EventoDetalheDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.TipoId, f => f.PickRandom<TipoEvento>())
+            .RuleFor(x => x.Tipo, f => f.Lorem.Word())
+            .RuleFor(x => x.Solicitante, f => f.Name.FullName())
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence())
+            .RuleFor(x => x.CodigoTombo, f => f.Random.Replace("TB-####"))
+            .RuleFor(x => x.AcervoSolicitacaoId, f => f.Random.Long(1, 500))
+            .RuleFor(x => x.Descricao, f => f.Lorem.Sentence())
+            .RuleFor(x => x.Justificativa, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.SituacaoSolicitacaoItemId, f => f.PickRandom<SituacaoSolicitacaoItem>())
+            .RuleFor(x => x.SituacaoSolicitacaoItemDescricao, f => f.Lorem.Word())
+            .RuleFor(x => x.Horario, f => $"{f.Random.Int(0, 23):D2}:{f.Random.Int(0, 59):D2}")
+            .Generate(quantidade);
+    }
+}

--- a/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/UsuarioControllerTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/WebApi/Controllers/UsuarioControllerTestes.cs
@@ -1,0 +1,388 @@
+﻿using Bogus;
+using Bogus.Extensions.Brazil;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using SME.CDEP.Webapi.Controllers;
+
+namespace SME.CDEP.TesteUnitario.Webapi.Controllers
+{
+    public class UsuarioControllerTestes
+    {
+        private readonly Mock<IServicoUsuario> servicoUsuarioMock;
+        private readonly UsuarioController sut;
+        private readonly Faker _faker;
+
+        public UsuarioControllerTestes()
+        {
+            var mocker = new AutoMocker();
+
+            servicoUsuarioMock = mocker.GetMock<IServicoUsuario>();
+
+            sut = mocker.CreateInstance<UsuarioController>();
+            _faker = new();
+        }
+
+        [Fact]
+        public async Task DadoUsuarioExternoValido_QuandoInserir_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var dto = GerarUsuarioExternoDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.InserirUsuarioExterno(dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.Inserir(dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.InserirUsuarioExterno(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLoginValido_QuandoSolicitarRecuperacaoSenha_EntaoRetornaOkComMensagem()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var mensagemRetorno = "Email de recuperação enviado com sucesso.";
+
+            servicoUsuarioMock
+                .Setup(s => s.SolicitarRecuperacaoSenha(login))
+                .ReturnsAsync(mensagemRetorno);
+
+            // Act
+            var resultado = await sut.SolicitarRecuperacaoSenha(login, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(mensagemRetorno);
+            servicoUsuarioMock.Verify(s => s.SolicitarRecuperacaoSenha(login), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTokenValido_QuandoTokenRecuperacaoSenhaEstaValidoAsync_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var token = Guid.NewGuid();
+
+            servicoUsuarioMock
+                .Setup(s => s.TokenRecuperacaoSenhaEstaValido(token))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.TokenRecuperacaoSenhaEstaValidoAsync(token, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.TokenRecuperacaoSenhaEstaValido(token), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoRecuperacaoSenhaValido_QuandoRecuperarSenha_EntaoRetornaOkComPerfilDeUsuario()
+        {
+            // Arrange
+            var dto = GerarRecuperacaoSenhaDto();
+            var retornoEsperado = GerarRetornoPerfilUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarSenhaComTokenRecuperacao(dto))
+                .ReturnsAsync(retornoEsperado);
+
+            // Act
+            var resultado = await sut.RecuperarSenha(dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(retornoEsperado);
+            servicoUsuarioMock.Verify(s => s.AlterarSenhaComTokenRecuperacao(dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLoginValido_QuandoMeusDados_EntaoRetornaOkComDadosDoUsuario()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dadosEsperados = GerarDadosUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.ObterMeusDados(login))
+                .ReturnsAsync(dadosEsperados);
+
+            // Act
+            var resultado = await sut.MeusDados(login, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dadosEsperados);
+            servicoUsuarioMock.Verify(s => s.ObterMeusDados(login), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoSenhaAlteracaoValida_QuandoAlterarSenha_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dto = GerarAlterarSenhaUsuarioDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarSenha(login, dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarSenha(login, dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.AlterarSenha(login, dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoEmailValido_QuandoAlterarEmail_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dto = new EmailUsuarioDTO { Email = _faker.Internet.Email() };
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarEmail(login, dto.Email))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarEmail(login, dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.AlterarEmail(login, dto.Email), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoEnderecoValido_QuandoAlterarEnderecoAcervo_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dto = GerarEnderecoUsuarioExternoDTO();
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarEndereco(login, dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarEnderecoAcervo(login, dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.AlterarEndereco(login, dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTelefoneValido_QuandoAlterarTelefoneAcervo_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dto = new TelefoneUsuarioExternoDTO { Telefone = _faker.Phone.PhoneNumber() };
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarTelefone(login, dto.Telefone))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarTelefoneAcervo(login, dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.AlterarTelefone(login, dto.Telefone), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoTipoUsuarioValido_QuandoAlterarTipoUsuario_EntaoRetornaOkComVerdadeiro()
+        {
+            // Arrange
+            var login = _faker.Internet.UserName();
+            var dto = new TipoUsuarioExternoDTO { Tipo = (int)TipoUsuario.ESTUDANTE };
+
+            servicoUsuarioMock
+                .Setup(s => s.AlterarTipoUsuario(login, dto))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.AlterarTipoUsuario(login, dto, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.AlterarTipoUsuario(login, dto), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoCpfValido_QuandoValidarCpfExistente_EntaoRetornaOkComResultado()
+        {
+            // Arrange
+            var cpf = _faker.Person.Cpf();
+
+            servicoUsuarioMock
+                .Setup(s => s.ValidarCpfExistente(cpf))
+                .ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.ValidarCpfExistente(cpf, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().Be(true);
+            servicoUsuarioMock.Verify(s => s.ValidarCpfExistente(cpf), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRequisicaoValida_QuandoObterDadosSolicitante_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var dadosEsperados = GerarDadosSolicitanteDto();
+
+            servicoUsuarioMock
+                .Setup(s => s.ObterDadosSolicitante())
+                .ReturnsAsync(dadosEsperados);
+
+            // Act
+            var resultado = await sut.ObterDadosSolicitante(servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dadosEsperados);
+            servicoUsuarioMock.Verify(s => s.ObterDadosSolicitante(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRequisicaoValida_QuandoObterUsuariosComPerfisResponsavel_EntaoRetornaOkComListaDeResponsaveis()
+        {
+            // Arrange
+            var listaEsperada = new List<ResponsavelDTO>
+            {
+                new() { Login = _faker.Internet.UserName(), Nome = _faker.Name.FullName() },
+                new() { Login = _faker.Internet.UserName(), Nome = _faker.Name.FullName() }
+            };
+
+            servicoUsuarioMock
+                .Setup(s => s.ObterUsuariosComPerfisResponsavel())
+                .ReturnsAsync(listaEsperada);
+
+            // Act
+            var resultado = await sut.ObterUsuariosComPerfisResponsavel(servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(listaEsperada);
+            servicoUsuarioMock.Verify(s => s.ObterUsuariosComPerfisResponsavel(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRfOuCpfValido_QuandoObterDadosSolicitantePorRfOuCpf_EntaoRetornaOkComDados()
+        {
+            // Arrange
+            var rfCpf = _faker.Random.Replace("#######");
+            var dadosEsperados = GerarDadosSolicitanteDto();
+
+            servicoUsuarioMock
+                .Setup(s => s.ObterDadosSolicitantePorRfOuCpf(rfCpf))
+                .ReturnsAsync(dadosEsperados);
+
+            // Act
+            var resultado = await sut.ObterDadosSolicitantePorRfOuCpf(rfCpf, servicoUsuarioMock.Object);
+
+            // Assert
+            var okResult = resultado.Should().BeOfType<OkObjectResult>().Subject;
+            okResult.Value.Should().BeEquivalentTo(dadosEsperados);
+            servicoUsuarioMock.Verify(s => s.ObterDadosSolicitantePorRfOuCpf(rfCpf), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static UsuarioExternoDTO GerarUsuarioExternoDTO() => new Faker<UsuarioExternoDTO>("pt_BR")
+            .RuleFor(x => x.Cpf, f => f.Person.Cpf(false))
+            .RuleFor(x => x.Email, f => f.Internet.Email())
+            .RuleFor(x => x.Nome, f => f.Name.FullName())
+            .RuleFor(x => x.Telefone, f => f.Phone.PhoneNumber())
+            .RuleFor(x => x.Endereco, f => f.Address.StreetName())
+            .RuleFor(x => x.Complemento, f => f.Address.SecondaryAddress())
+            .RuleFor(x => x.Numero, f => f.Address.BuildingNumber())
+            .RuleFor(x => x.Cidade, f => f.Address.City())
+            .RuleFor(x => x.Estado, f => f.Address.StateAbbr())
+            .RuleFor(x => x.Cep, f => f.Address.ZipCode())
+            .RuleFor(x => x.Senha, f => "Senha@123")
+            .RuleFor(x => x.ConfirmarSenha, f => "Senha@123")
+            .RuleFor(x => x.Tipo, f => f.PickRandom<TipoUsuario>())
+            .RuleFor(x => x.Bairro, f => f.Address.County())
+            .RuleFor(x => x.Instituicao, f => f.Company.CompanyName())
+            .Generate();
+
+        private static RecuperacaoSenhaDto GerarRecuperacaoSenhaDto() => new Faker<RecuperacaoSenhaDto>("pt_BR")
+            .RuleFor(x => x.NovaSenha, f => f.Internet.Password())
+            .RuleFor(x => x.Token, f => Guid.NewGuid())
+            .Generate();
+
+        private static DadosUsuarioDTO GerarDadosUsuarioDTO() => new Faker<DadosUsuarioDTO>("pt_BR")
+            .RuleFor(x => x.Nome, f => f.Name.FullName())
+            .RuleFor(x => x.Cpf, f => f.Person.Cpf(false))
+            .RuleFor(x => x.Login, f => f.Internet.UserName())
+            .RuleFor(x => x.Email, f => f.Internet.Email())
+            .RuleFor(x => x.Telefone, f => f.Phone.PhoneNumber())
+            .RuleFor(x => x.Endereco, f => f.Address.StreetName())
+            .RuleFor(x => x.Numero, f => f.Address.BuildingNumber())
+            .RuleFor(x => x.Complemento, f => f.Address.SecondaryAddress())
+            .RuleFor(x => x.Bairro, f => f.Address.County())
+            .RuleFor(x => x.Cep, f => f.Address.ZipCode())
+            .RuleFor(x => x.Cidade, f => f.Address.City())
+            .RuleFor(x => x.Estado, f => f.Address.StateAbbr())
+            .RuleFor(x => x.Tipo, f => f.Random.Int(1, 5))
+            .RuleFor(x => x.Instituicao, f => f.Company.CompanyName())
+            .Generate();
+
+        private static AlterarSenhaUsuarioDTO GerarAlterarSenhaUsuarioDTO() => new Faker<AlterarSenhaUsuarioDTO>("pt_BR")
+            .RuleFor(x => x.SenhaAtual, f => "Antiga@123")
+            .RuleFor(x => x.SenhaNova, f => "Nova@1234")
+            .RuleFor(x => x.ConfirmarSenha, f => "Nova@1234")
+            .Generate();
+
+        private static EnderecoUsuarioExternoDTO GerarEnderecoUsuarioExternoDTO() => new Faker<EnderecoUsuarioExternoDTO>("pt_BR")
+            .RuleFor(x => x.Endereco, f => f.Address.StreetName())
+            .RuleFor(x => x.Complemento, f => f.Address.SecondaryAddress())
+            .RuleFor(x => x.Numero, f => f.Address.BuildingNumber())
+            .RuleFor(x => x.Cidade, f => f.Address.City())
+            .RuleFor(x => x.Estado, f => f.Address.StateAbbr())
+            .RuleFor(x => x.Cep, f => f.Address.ZipCode())
+            .RuleFor(x => x.Bairro, f => f.Address.County())
+            .Generate();
+
+        private static DadosSolicitanteDto GerarDadosSolicitanteDto() => new Faker<DadosSolicitanteDto>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.Nome, f => f.Name.FullName())
+            .RuleFor(x => x.Login, f => f.Internet.UserName())
+            .RuleFor(x => x.Telefone, f => f.Phone.PhoneNumber())
+            .RuleFor(x => x.Endereco, f => f.Address.FullAddress())
+            .RuleFor(x => x.Email, f => f.Internet.Email())
+            .RuleFor(x => x.Tipo, f => f.Name.JobTitle())
+            .RuleFor(x => x.TipoId, f => f.PickRandom<TipoUsuario>())
+            .Generate();
+
+        private static RetornoPerfilUsuarioDTO GerarRetornoPerfilUsuarioDTO() => new Faker<RetornoPerfilUsuarioDTO>("pt_BR")
+            .RuleFor(x => x.UsuarioNome, f => f.Name.FullName())
+            .RuleFor(x => x.UsuarioLogin, f => f.Internet.UserName())
+            .RuleFor(x => x.DataHoraExpiracao, f => f.Date.Future())
+            .RuleFor(x => x.Token, f => f.Random.Hash())
+            .RuleFor(x => x.Email, f => f.Internet.Email())
+            .RuleFor(x => x.Autenticado, f => true)
+            .RuleFor(x => x.PerfilUsuario, f => new List<PerfilUsuarioDTO> { new(Guid.NewGuid(), "Admin") })
+            .Generate();
+    }
+}


### PR DESCRIPTION
#### Classificação do PR
Novo recurso e melhoria na qualidade do código: adiciona ampla cobertura de testes unitários e refatorações para melhor testabilidade e manutenção.

#### Resumo do PR
Este pull request introduz um conjunto abrangente de testes unitários para os serviços de aplicação SME.CDEP, extensões de domínio e controladores de API web, além de refatorar classes principais para melhorar a testabilidade e a qualidade do código.

- Adicionados novos arquivos de teste unitário para controladores principais (por exemplo, AcervoBibliograficoControllerTestes.cs, UsuarioControllerTestes.cs) e serviços de aplicação usando Moq, FluentAssertions e Bogus.

- Refatoradas as classes de aplicação e infraestrutura para usar injeção de dependência com construtores primários do C#.

- Classes de infraestrutura e integração marcadas com [ExcludeFromCodeCoverage] para focar as métricas de cobertura na lógica de negócios.

- Processamento de imagens atualizado para usar SixLabors.ImageSharp e tratamento de erros aprimorado em casos de uso de notificação/importação.
- Padronização do uso de diretivas e aprimoramento da validação de parâmetros e do uso de métodos auxiliares em toda a base de código.

[AB#146238](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/146238)