### PR TITLE
test: Refatora e amplia testes de acervo bibliográfico e 3D

### DIFF
--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoAcervoBibliograficoTests.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoAcervoBibliograficoTests.cs
@@ -1,193 +1,452 @@
-﻿using Bogus;
+﻿using AutoMapper;
+using Bogus;
 using FluentAssertions;
 using Moq;
 using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
 using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
 using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Enumerados;
 using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados;
 using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
 using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Data;
 
 namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
 {
-    public class ServicoAcervoBibliograficoTests
+    public class ServicoAcervoBibliograficoTestes
     {
-        private readonly AutoMocker _mocker;
-        private readonly ServicoAcervoBibliografico _servico;
-        private readonly Faker _faker;
+        private readonly Mock<IRepositorioAcervoBibliograficoAssunto> repositorioAcervoBibliograficoAssuntoMock;
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<ITransacao> transacaoMock;
+        private readonly Mock<IRepositorioAcervoBibliografico> repositorioAcervoBibliograficoMock;
+        private readonly Mock<IRepositorioAssunto> repositorioAssuntoMock;
+        private readonly Mock<IServicoAcervo> servicoAcervoMock;
+        private readonly Mock<IRepositorioAcervoEmprestimo> repositorioAcervoEmprestimoMock;
+        private readonly Mock<IDbTransaction> dbTransactionMock;
+        private readonly ServicoAcervoBibliografico sut;
 
-        public ServicoAcervoBibliograficoTests()
+        public ServicoAcervoBibliograficoTestes()
         {
-            _mocker = new AutoMocker();
-            _servico = _mocker.CreateInstance<ServicoAcervoBibliografico>();
-            _faker = new Faker("pt_BR");
+            var mocker = new AutoMocker();
+
+            repositorioAcervoBibliograficoAssuntoMock = mocker.GetMock<IRepositorioAcervoBibliograficoAssunto>();
+            mapperMock = mocker.GetMock<IMapper>();
+            transacaoMock = mocker.GetMock<ITransacao>();
+            repositorioAcervoBibliograficoMock = mocker.GetMock<IRepositorioAcervoBibliografico>();
+            repositorioAssuntoMock = mocker.GetMock<IRepositorioAssunto>();
+            servicoAcervoMock = mocker.GetMock<IServicoAcervo>();
+            repositorioAcervoEmprestimoMock = mocker.GetMock<IRepositorioAcervoEmprestimo>();
+            dbTransactionMock = new Mock<IDbTransaction>();
+
+            transacaoMock.Setup(t => t.Iniciar()).Returns(dbTransactionMock.Object);
+
+            sut = mocker.CreateInstance<ServicoAcervoBibliografico>();
         }
 
-        #region AlterarSituacaoSaldo
-
-        [Fact(DisplayName = "Dado um acervo existente, Quando AlterarSituacaoSaldo, Então deve atualizar o saldo no banco")]
-        public async Task AlterarSituacaoSaldo_AcervoExistente_DeveAtualizar()
+        [Fact]
+        public async Task DadoDtoValido_QuandoInserir_EntaoInsereAcervoAcervoBibliograficoEAssuntosComitaTransacaoERetornaId()
         {
             // Arrange
-            var acervoId = _faker.Random.Long(1);
-            var situacaoEsperada = SituacaoSaldo.EMPRESTADO;
-            var acervoBibliografico = new AcervoBibliografico { AcervoId = acervoId, SituacaoSaldo = SituacaoSaldo.DISPONIVEL };
+            var dto = GerarAcervoBibliograficoCadastroDTO();
+            var acervo = new Acervo();
+            var acervoBibliografico = new AcervoBibliografico();
+            var assuntos = new List<Assunto> { new() { Id = 1 }, new() { Id = 2 } };
+            var idGerado = 99L;
 
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Setup(r => r.ObterPorAcervoId(acervoId))
-                .ReturnsAsync(acervoBibliografico);
+            repositorioAssuntoMock.Setup(r => r.ObterPorIds(dto.AssuntosIds)).ReturnsAsync(assuntos);
+            mapperMock.Setup(m => m.Map<Acervo>(dto)).Returns(acervo);
+            mapperMock.Setup(m => m.Map<AcervoBibliografico>(dto)).Returns(acervoBibliografico);
+            servicoAcervoMock.Setup(s => s.Inserir(acervo)).ReturnsAsync(idGerado);
+            repositorioAcervoBibliograficoMock.Setup(r => r.Inserir(acervoBibliografico)).ReturnsAsync(idGerado);
 
             // Act
-            var resultado = await _servico.AlterarSituacaoSaldo(situacaoEsperada, acervoId);
+            var resultado = await sut.Inserir(dto);
+
+            // Assert
+            resultado.Should().Be(idGerado);
+            acervo.Situacao.Should().Be(SituacaoAcervo.Ativo);
+            acervo.TipoAcervoId.Should().Be((int)TipoAcervo.Bibliografico);
+            acervoBibliografico.AcervoId.Should().Be(idGerado);
+
+            servicoAcervoMock.Verify(s => s.Inserir(acervo), Times.Once);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Inserir(acervoBibliografico), Times.Once);
+            repositorioAcervoBibliograficoAssuntoMock.Verify(r => r.Inserir(It.IsAny<AcervoBibliograficoAssunto>()), Times.Exactly(assuntos.Count));
+            dbTransactionMock.Verify(t => t.Commit(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLarguraComFormatoInvalido_QuandoInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoCadastroDTO();
+            dto.Largura = "10.5";
+
+            // Act
+            Func<Task> acao = async () => await sut.Inserir(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.LARGURA));
+        }
+
+        [Fact]
+        public async Task DadoAlturaComFormatoInvalido_QuandoInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoCadastroDTO();
+            dto.Altura = "10.5";
+
+            // Act
+            Func<Task> acao = async () => await sut.Inserir(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.ALTURA));
+        }
+
+        [Fact]
+        public async Task DadoExcecaoLancadaPorQualquerDependencia_QuandoInserir_EntaoRealizaRollbackNaTransacaoERelancaExcecao()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoCadastroDTO();
+            var assuntos = new List<Assunto> { new() { Id = 1 }, new() { Id = 2 } };
+            repositorioAssuntoMock.Setup(r => r.ObterPorIds(dto.AssuntosIds)).ReturnsAsync(assuntos);
+            mapperMock.Setup(m => m.Map<Acervo>(dto)).Returns(new Acervo());
+            servicoAcervoMock.Setup(r => r.Inserir(It.IsAny<Acervo>())).ThrowsAsync(new Exception());
+
+            // Act
+            Func<Task> acao = async () => await sut.Inserir(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<Exception>();
+            dbTransactionMock.Verify(t => t.Rollback(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervosCadastrados_QuandoObterTodos_EntaoRetornaListaDeAcervosBibliograficosDto()
+        {
+            // Arrange
+            var entidades = new List<AcervoBibliografico> { new(), new() };
+            var dtos = new List<AcervoBibliograficoDTO> { new(), new() };
+
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterTodos()).ReturnsAsync(entidades);
+            mapperMock.Setup(m => m.Map<AcervoBibliograficoDTO>(It.IsAny<AcervoBibliografico>())).Returns(dtos[0]);
+
+            // Act
+            var resultado = await sut.ObterTodos();
+
+            // Assert
+            resultado.Should().HaveCount(2);
+            repositorioAcervoBibliograficoMock.Verify(r => r.ObterTodos(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoDtoValidoComNovosAssuntosEAssuntosAExcluir_QuandoAlterar_EntaoAtualizaAcervosInsereEExcluiAssuntosComitaTransacaoERetornaDtoAtualizado()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoAlteracaoDTO();
+            dto.AssuntosIds = [1L, 3L];
+            var assuntosExistentesNoBanco = new List<AcervoBibliograficoAssunto>
+            {
+                new() { AssuntoId = 1L },
+                new() { AssuntoId = 2L }
+            };
+
+            var acervoBibliografico = new AcervoBibliografico { Id = dto.Id };
+            var acervoDtoMap = new AcervoDto();
+            var dtoRetornoFinal = new AcervoBibliograficoDTO { Id = dto.Id };
+
+            mapperMock.Setup(m => m.Map<AcervoBibliografico>(dto)).Returns(acervoBibliografico);
+            mapperMock.Setup(m => m.Map<AcervoDto>(dto)).Returns(acervoDtoMap);
+
+            repositorioAcervoBibliograficoAssuntoMock
+                .Setup(r => r.ObterPorAcervoBibliograficoId(dto.Id))
+                .ReturnsAsync(assuntosExistentesNoBanco);
+
+            var acervoBibliograficoCompleto = new AcervoBibliograficoCompleto();
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterAcervoBibliograficoCompletoPorId(dto.AcervoId)).ReturnsAsync(acervoBibliograficoCompleto);
+            mapperMock.Setup(m => m.Map<AcervoBibliograficoDTO>(acervoBibliograficoCompleto)).Returns(dtoRetornoFinal);
+
+            // Act
+            var resultado = await sut.Alterar(dto);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            servicoAcervoMock.Verify(s => s.Alterar(acervoDtoMap), Times.Once);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(acervoBibliografico), Times.Once);
+            repositorioAcervoBibliograficoAssuntoMock.Verify(r => r.Inserir(It.Is<AcervoBibliograficoAssunto>(a => a.AssuntoId == 3L)), Times.Once);
+            repositorioAcervoBibliograficoAssuntoMock.Verify(r => r.Excluir(It.Is<long[]>(a => a.Contains(2L)), acervoBibliografico.Id), Times.Once);
+            dbTransactionMock.Verify(t => t.Commit(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoLarguraComFormatoInvalido_QuandoAlterar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoAlteracaoDTO();
+            dto.Largura = "10.5";
+
+            // Act
+            Func<Task> acao = async () => await sut.Alterar(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.LARGURA));
+        }
+
+        [Fact]
+        public async Task DadoAlturaComFormatoInvalido_QuandoAlterar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoAlteracaoDTO();
+            dto.Altura = "10.5";
+
+            // Act
+            Func<Task> acao = async () => await sut.Alterar(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.ALTURA));
+        }
+
+        [Fact]
+        public async Task DadoExcecaoLancadaPorQualquerDependencia_QuandoAlterar_EntaoRealizaRollbackNaTransacaoERelancaExcecao()
+        {
+            // Arrange
+            var dto = GerarAcervoBibliograficoAlteracaoDTO();
+            var assuntosExistentesNoBanco = new List<AcervoBibliograficoAssunto>
+            {
+                new() { AssuntoId = 1L },
+                new() { AssuntoId = 2L }
+            };
+
+            repositorioAcervoBibliograficoAssuntoMock
+                .Setup(r => r.ObterPorAcervoBibliograficoId(dto.Id))
+                .ReturnsAsync(assuntosExistentesNoBanco);
+            servicoAcervoMock.Setup(r => r.Alterar(It.IsAny<AcervoDto>())).ThrowsAsync(new Exception());
+
+            // Act
+            Func<Task> acao = async () => await sut.Alterar(dto);
+
+            // Assert
+            await acao.Should().ThrowAsync<Exception>();
+            dbTransactionMock.Verify(t => t.Rollback(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdExistente_QuandoObterPorId_EntaoRetornaAcervoBibliograficoDtoMapeadoComAuditoria()
+        {
+            // Arrange
+            var id = 1L;
+            var entidadeCompleta = new AcervoBibliograficoCompleto();
+            var dto = new AcervoBibliograficoDTO();
+            var auditoriaDto = new AuditoriaDTO();
+
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterAcervoBibliograficoCompletoPorId(id)).ReturnsAsync(entidadeCompleta);
+            mapperMock.Setup(m => m.Map<AcervoBibliograficoDTO>(entidadeCompleta)).Returns(dto);
+            mapperMock.Setup(m => m.Map<AuditoriaDTO>(entidadeCompleta)).Returns(auditoriaDto);
+
+            // Act
+            var resultado = await sut.ObterPorId(id);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Should().Be(dto);
+            resultado.Auditoria.Should().Be(auditoriaDto);
+        }
+
+        [Fact]
+        public async Task DadoIdInexistente_QuandoObterPorId_EntaoRetornaNulo()
+        {
+            // Arrange
+            var id = 1L;
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterAcervoBibliograficoCompletoPorId(id)).ReturnsAsync((AcervoBibliograficoCompleto)null!);
+
+            // Act
+            var resultado = await sut.ObterPorId(id);
+
+            // Assert
+            resultado.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task DadoIdValido_QuandoExcluir_EntaoChamaExclusaoNoServicoAcervoERetornaResultadoBooleano()
+        {
+            // Arrange
+            var id = 1L;
+            servicoAcervoMock.Setup(s => s.Excluir(id)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await sut.Excluir(id);
 
             // Assert
             resultado.Should().BeTrue();
-            acervoBibliografico.SituacaoSaldo.Should().Be(situacaoEsperada); // Verifica alteração na memória
-
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Verify(r => r.Atualizar(acervoBibliografico), Times.Once);
+            servicoAcervoMock.Verify(s => s.Excluir(id), Times.Once);
         }
 
-        [Fact(DisplayName = "Dado um acervo inexistente, Quando AlterarSituacaoSaldo, Então deve retornar falso e não atualizar")]
-        public async Task AlterarSituacaoSaldo_AcervoInexistente_DeveRetornarFalso()
+        [Fact]
+        public async Task DadoIdExistente_QuandoAlterarSituacaoSaldo_EntaoAtualizaSituacaoNoRepositorioERetornaVerdadeiro()
         {
+            // Arrange
+            var id = 1L;
+            var situacao = SituacaoSaldo.RESERVADO;
+            var acervo = new AcervoBibliografico { SituacaoSaldo = SituacaoSaldo.DISPONIVEL };
+
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(id)).ReturnsAsync(acervo);
+
             // Act
-            var resultado = await _servico.AlterarSituacaoSaldo(SituacaoSaldo.RESERVADO, 1);
+            var resultado = await sut.AlterarSituacaoSaldo(situacao, id);
+
+            // Assert
+            resultado.Should().BeTrue();
+            acervo.SituacaoSaldo.Should().Be(situacao);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(acervo), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoIdInexistente_QuandoAlterarSituacaoSaldo_EntaoNaoAtualizaERetornaFalso()
+        {
+            // Arrange
+            var id = 1L;
+            var situacao = SituacaoSaldo.RESERVADO;
+
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(id)).ReturnsAsync((AcervoBibliografico)null!);
+
+            // Act
+            var resultado = await sut.AlterarSituacaoSaldo(situacao, id);
 
             // Assert
             resultado.Should().BeFalse();
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Verify(r => r.Atualizar(It.IsAny<AcervoBibliografico>()), Times.Never);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(It.IsAny<AcervoBibliografico>()), Times.Never);
         }
 
-        #endregion
-
-        #region GerenciarEmprestimoAsync (Fluxo Confirmação)
-
-        [Fact(DisplayName = "Dado que já existe empréstimo, Quando GerenciarEmprestimo, Então deve lançar exceção")]
-        public async Task GerenciarEmprestimo_ItemJaEmprestado_DeveLancarExcecao()
+        [Fact]
+        public async Task DadoItemJaPossuiEmprestimo_QuandoGerenciarEmprestimoAsync_EntaoLancaNegocioExceptionDeAlteracaoNaoPermitida()
         {
             // Arrange
             var itemId = 1L;
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId))
-                .ReturnsAsync(new AcervoEmprestimo()); // Retorna algo, simulando existência
-
-            // Act & Assert
-            await Assert.ThrowsAsync<NegocioException>(() =>
-                _servico.GerenciarEmprestimoAsync(itemId, 1, DateTime.Now, DateTime.Now));
-        }
-
-        [Fact(DisplayName = "Dado datas válidas, Quando GerenciarEmprestimo, Então deve inserir empréstimo e marcar saldo como EMPRESTADO")]
-        public async Task GerenciarEmprestimo_ComDatas_DeveInserirEAtualizarSaldo()
-        {
-            // Arrange
-            var itemId = _faker.Random.Long(1);
-            var acervoId = _faker.Random.Long(1);
-            var dataEmp = DateTime.Now;
-            var dataDev = DateTime.Now.AddDays(7);
-
-            // Mock necessário para o AlterarSituacaoSaldo funcionar internamente
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Setup(r => r.ObterPorAcervoId(acervoId))
-                .ReturnsAsync(new AcervoBibliografico());
+            repositorioAcervoEmprestimoMock.Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId)).ReturnsAsync(new AcervoEmprestimo());
 
             // Act
-            await _servico.GerenciarEmprestimoAsync(itemId, acervoId, dataEmp, dataDev);
+            Func<Task> acao = async () => await sut.GerenciarEmprestimoAsync(itemId, 2L, DateTime.Now, DateTime.Now);
 
             // Assert
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Verify(r => r.Inserir(It.Is<AcervoEmprestimo>(e =>
-                    e.AcervoSolicitacaoItemId == itemId &&
-                    e.Situacao == SituacaoEmprestimo.EMPRESTADO &&
-                    e.DataEmprestimo == dataEmp &&
-                    e.DataDevolucao == dataDev
-                )), Times.Once);
-
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.EMPRESTADO)), Times.Once);
+            await acao.Should().ThrowAsync<NegocioException>().WithMessage(MensagemNegocio.VOCE_NAO_PODE_ALTERAR_EMPRESTIMOS_ACERVOS);
         }
 
-        [Fact(DisplayName = "Dado sem datas de empréstimo, Quando GerenciarEmprestimo, Então deve apenas reservar saldo")]
-        public async Task GerenciarEmprestimo_SemDatas_DeveApenasReservar()
+        [Fact]
+        public async Task DadoItemSemEmprestimoEComDatasPreenchidas_QuandoGerenciarEmprestimoAsync_EntaoInsereNovoEmprestimoEAlteraSaldoParaEmprestado()
         {
             // Arrange
             var itemId = 1L;
             var acervoId = 2L;
+            var acervo = new AcervoBibliografico();
 
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Setup(r => r.ObterPorAcervoId(acervoId))
-                .ReturnsAsync(new AcervoBibliografico());
-
-            // Act (Passando null nas datas)
-            await _servico.GerenciarEmprestimoAsync(itemId, acervoId, null, null);
-
-            // Assert
-            // Não deve inserir empréstimo
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>().Verify(r => r.Inserir(It.IsAny<AcervoEmprestimo>()), Times.Never);
-
-            // Deve atualizar saldo para RESERVADO
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.RESERVADO)), Times.Once);
-        }
-
-        #endregion
-
-        #region AtualizarOuCriarEmprestimoAsync (Fluxo Manutenção)
-
-        [Fact(DisplayName = "Dado empréstimo inexistente, Quando AtualizarOuCriar, Então deve inserir novo")]
-        public async Task AtualizarOuCriarEmprestimo_Inexistente_DeveInserir()
-        {
-            // Arrange
-            var itemId = _faker.Random.Long(1);
-            var acervoId = _faker.Random.Long(1);
-
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Setup(r => r.ObterPorAcervoId(acervoId))
-                .ReturnsAsync(new AcervoBibliografico());
+            repositorioAcervoEmprestimoMock.Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId)).ReturnsAsync((AcervoEmprestimo)null!);
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(acervoId)).ReturnsAsync(acervo);
 
             // Act
-            await _servico.AtualizarOuCriarEmprestimoAsync(itemId, acervoId, DateTime.Now, DateTime.Now.AddDays(7));
+            await sut.GerenciarEmprestimoAsync(itemId, acervoId, DateTime.Now, DateTime.Now);
 
             // Assert
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Verify(r => r.Inserir(It.IsAny<AcervoEmprestimo>()), Times.Once);
-
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Verify(r => r.Atualizar(It.IsAny<AcervoEmprestimo>()), Times.Never);
+            repositorioAcervoEmprestimoMock.Verify(r => r.Inserir(It.Is<AcervoEmprestimo>(a => a.Situacao == SituacaoEmprestimo.EMPRESTADO)), Times.Once);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.EMPRESTADO)), Times.Once);
         }
 
-        [Fact(DisplayName = "Dado empréstimo existente, Quando AtualizarOuCriar, Então deve atualizar dados")]
-        public async Task AtualizarOuCriarEmprestimo_Existente_DeveAtualizar()
+        [Fact]
+        public async Task DadoItemSemEmprestimoESemDatasPreenchidas_QuandoGerenciarEmprestimoAsync_EntaoNaoInsereEmprestimoEAlteraSaldoParaReservado()
         {
             // Arrange
-            var itemId = _faker.Random.Long(1);
-            var emprestimoExistente = new AcervoEmprestimo { Id = 10, AcervoSolicitacaoItemId = itemId };
-            var novaDataDevolucao = DateTime.Now.AddDays(15);
+            var itemId = 1L;
+            var acervoId = 2L;
+            var acervo = new AcervoBibliografico();
 
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId))
-                .ReturnsAsync(emprestimoExistente);
-
-            _mocker.GetMock<IRepositorioAcervoBibliografico>()
-                .Setup(r => r.ObterPorAcervoId(It.IsAny<long>()))
-                .ReturnsAsync(new AcervoBibliografico());
+            repositorioAcervoEmprestimoMock.Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId)).ReturnsAsync((AcervoEmprestimo)null!);
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(acervoId)).ReturnsAsync(acervo);
 
             // Act
-            await _servico.AtualizarOuCriarEmprestimoAsync(itemId, 1, DateTime.Now, novaDataDevolucao);
+            await sut.GerenciarEmprestimoAsync(itemId, acervoId, null, null);
 
             // Assert
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Verify(r => r.Atualizar(It.Is<AcervoEmprestimo>(e =>
-                    e.Id == 10 &&
-                    e.DataDevolucao == novaDataDevolucao &&
-                    e.Situacao == SituacaoEmprestimo.EMPRESTADO
-                )), Times.Once);
-
-            _mocker.GetMock<IRepositorioAcervoEmprestimo>()
-                .Verify(r => r.Inserir(It.IsAny<AcervoEmprestimo>()), Times.Never);
+            repositorioAcervoEmprestimoMock.Verify(r => r.Inserir(It.IsAny<AcervoEmprestimo>()), Times.Never);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.RESERVADO)), Times.Once);
         }
 
-        #endregion
+        [Fact]
+        public async Task DadoItemComEmprestimoExistente_QuandoAtualizarOuCriarEmprestimoAsync_EntaoAtualizaDatasESituacaoParaEmprestadoEAlteraSaldoParaEmprestado()
+        {
+            // Arrange
+            var itemId = 1L;
+            var acervoId = 2L;
+            var dataNova = DateTime.Now.AddDays(1);
+            var emprestimo = new AcervoEmprestimo { Situacao = SituacaoEmprestimo.DEVOLUCAO_EM_ATRASO };
+            var acervo = new AcervoBibliografico();
+
+            repositorioAcervoEmprestimoMock.Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId)).ReturnsAsync(emprestimo);
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(acervoId)).ReturnsAsync(acervo);
+
+            // Act
+            await sut.AtualizarOuCriarEmprestimoAsync(itemId, acervoId, dataNova, dataNova);
+
+            // Assert
+            emprestimo.DataEmprestimo.Should().Be(dataNova);
+            emprestimo.DataDevolucao.Should().Be(dataNova);
+            emprestimo.Situacao.Should().Be(SituacaoEmprestimo.EMPRESTADO);
+
+            repositorioAcervoEmprestimoMock.Verify(r => r.Atualizar(emprestimo), Times.Once);
+            repositorioAcervoEmprestimoMock.Verify(r => r.Inserir(It.IsAny<AcervoEmprestimo>()), Times.Never);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.EMPRESTADO)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoItemSemEmprestimoExistente_QuandoAtualizarOuCriarEmprestimoAsync_EntaoInsereNovoEmprestimoEAlteraSaldoParaEmprestado()
+        {
+            // Arrange
+            var itemId = 1L;
+            var acervoId = 2L;
+            var dataNova = DateTime.Now;
+            var acervo = new AcervoBibliografico();
+
+            repositorioAcervoEmprestimoMock.Setup(r => r.ObterUltimoEmprestimoPorAcervoSolicitacaoItemId(itemId)).ReturnsAsync((AcervoEmprestimo)null!);
+            repositorioAcervoBibliograficoMock.Setup(r => r.ObterPorAcervoId(acervoId)).ReturnsAsync(acervo);
+
+            // Act
+            await sut.AtualizarOuCriarEmprestimoAsync(itemId, acervoId, dataNova, dataNova);
+
+            // Assert
+            repositorioAcervoEmprestimoMock.Verify(r => r.Atualizar(It.IsAny<AcervoEmprestimo>()), Times.Never);
+            repositorioAcervoEmprestimoMock.Verify(r => r.Inserir(It.Is<AcervoEmprestimo>(a => a.Situacao == SituacaoEmprestimo.EMPRESTADO)), Times.Once);
+            repositorioAcervoBibliograficoMock.Verify(r => r.Atualizar(It.Is<AcervoBibliografico>(a => a.SituacaoSaldo == SituacaoSaldo.EMPRESTADO)), Times.Once);
+        }
+
+        // ================= HELPER BOGUS GENERATORS ================= //
+
+        private static AcervoBibliograficoCadastroDTO GerarAcervoBibliograficoCadastroDTO() => new Faker<AcervoBibliograficoCadastroDTO>("pt_BR")
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.MaterialId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.IdiomaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.LocalizacaoCDD, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.AssuntosIds, f => new[] { f.Random.Long(1, 10) })
+            .RuleFor(x => x.Largura, f => "10,50")
+            .RuleFor(x => x.Altura, f => "20,00")
+            .Generate();
+
+        private static AcervoBibliograficoAlteracaoDTO GerarAcervoBibliograficoAlteracaoDTO() => new Faker<AcervoBibliograficoAlteracaoDTO>("pt_BR")
+            .RuleFor(x => x.Id, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.AcervoId, f => f.Random.Long(1, 1000))
+            .RuleFor(x => x.Titulo, f => f.Lorem.Sentence(3))
+            .RuleFor(x => x.Ano, f => f.Date.Past().Year.ToString())
+            .RuleFor(x => x.MaterialId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.IdiomaId, f => f.Random.Long(1, 100))
+            .RuleFor(x => x.LocalizacaoCDD, f => f.Random.AlphaNumeric(10))
+            .RuleFor(x => x.AssuntosIds, f => new[] { f.Random.Long(1, 10) })
+            .RuleFor(x => x.Largura, f => "10,50")
+            .RuleFor(x => x.Altura, f => "20,00")
+            .Generate();
     }
 }

--- a/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoAcervoTridimensionalTestes.cs
+++ b/teste/SME.CDEP.TesteUnitario/Aplicacao/Servicos/ServicoAcervoTridimensionalTestes.cs
@@ -1,0 +1,411 @@
+﻿using AutoMapper;
+using FluentAssertions;
+using Moq;
+using Moq.AutoMock;
+using SME.CDEP.Aplicacao.DTOS;
+using SME.CDEP.Aplicacao.Servicos;
+using SME.CDEP.Aplicacao.Servicos.Interface;
+using SME.CDEP.Dominio.Constantes;
+using SME.CDEP.Dominio.Entidades;
+using SME.CDEP.Dominio.Excecoes;
+using SME.CDEP.Infra.Dados;
+using SME.CDEP.Infra.Dados.Repositorios.Interfaces;
+using SME.CDEP.Infra.Dominio.Enumerados;
+using System.Data;
+
+namespace SME.CDEP.TesteUnitario.Aplicacao.Servicos
+{
+    public class ServicoAcervoTridimensionalTestes
+    {
+        private readonly Mock<IRepositorioAcervoTridimensional> _repositorioAcervoTridimensionalMock;
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<ITransacao> _transacaoMock;
+        private readonly Mock<IServicoAcervo> _servicoAcervoMock;
+        private readonly Mock<IRepositorioArquivo> _repositorioArquivoMock;
+        private readonly Mock<IRepositorioAcervoTridimensionalArquivo> _repositorioAcervoTridimensionalArquivoMock;
+        private readonly Mock<IServicoMoverArquivoTemporario> _servicoMoverArquivoTemporarioMock;
+        private readonly ServicoAcervoTridimensional _sut;
+
+        public ServicoAcervoTridimensionalTestes()
+        {
+            var mocker = new AutoMocker();
+
+            _repositorioAcervoTridimensionalMock = mocker.GetMock<IRepositorioAcervoTridimensional>();
+            _mapperMock = mocker.GetMock<IMapper>();
+            _transacaoMock = mocker.GetMock<ITransacao>();
+            _servicoAcervoMock = mocker.GetMock<IServicoAcervo>();
+            _repositorioArquivoMock = mocker.GetMock<IRepositorioArquivo>();
+            _repositorioAcervoTridimensionalArquivoMock = mocker.GetMock<IRepositorioAcervoTridimensionalArquivo>();
+            _servicoMoverArquivoTemporarioMock = mocker.GetMock<IServicoMoverArquivoTemporario>();
+
+            _sut = mocker.CreateInstance<ServicoAcervoTridimensional>();
+        }
+
+        [Fact]
+        public async Task DadoCreditosAutoresPreenchidos_QuandoChamarInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                CreditosAutoresIds = [1, 2]
+            };
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.ESSE_ACERVO_NAO_POSSUI_CREDITO_OU_AUTOR);
+        }
+
+        [Fact]
+        public async Task DadoLarguraComFormatoInvalido_QuandoChamarInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Largura = "valor_invalido"
+            };
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.LARGURA));
+        }
+
+        [Fact]
+        public async Task DadoAlturaComFormatoInvalido_QuandoChamarInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Altura = "valor_invalido"
+            };
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.ALTURA));
+        }
+
+        [Fact]
+        public async Task DadoProfundidadeComFormatoInvalido_QuandoChamarInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Profundidade = "valor_invalido"
+            };
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.PROFUNDIDADE));
+        }
+
+        [Fact]
+        public async Task DadoDiametroComFormatoInvalido_QuandoChamarInserir_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Diametro = "valor_invalido"
+            };
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.DIAMETRO));
+        }
+
+        [Fact]
+        public async Task DadoAcervoValidoComArquivos_QuandoChamarInserir_EntaoExecutaFluxoCompletoERetornaId()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Codigo = "COD123",
+                Arquivos = [1, 2]
+            };
+            var arquivos = new List<Arquivo> { new() { Id = 1 }, new() { Id = 2 } };
+            var acervoMapeado = new Acervo { Codigo = "COD123" };
+            var acervoTridimensionalMapeado = new AcervoTridimensional();
+            var acervoIdRetornado = 99L;
+            var transactionMock = new Mock<IDbTransaction>();
+
+            _repositorioArquivoMock.Setup(r => r.ObterPorIds(dto.Arquivos)).ReturnsAsync(arquivos);
+            _mapperMock.Setup(m => m.Map<Acervo>(dto)).Returns(acervoMapeado);
+            _mapperMock.Setup(m => m.Map<AcervoTridimensional>(dto)).Returns(acervoTridimensionalMapeado);
+            _transacaoMock.Setup(t => t.Iniciar()).Returns(transactionMock.Object);
+            _servicoAcervoMock.Setup(s => s.Inserir(acervoMapeado)).ReturnsAsync(acervoIdRetornado);
+
+            // Act
+            var resultado = await _sut.Inserir(dto);
+
+            // Assert
+            resultado.Should().Be(acervoIdRetornado);
+            acervoMapeado.Codigo.Should().EndWith(Constantes.SIGLA_ACERVO_TRIDIMENSIONAL);
+            _repositorioAcervoTridimensionalMock.Verify(r => r.Inserir(acervoTridimensionalMapeado), Times.Once);
+            _repositorioAcervoTridimensionalArquivoMock.Verify(r => r.Inserir(It.IsAny<AcervoTridimensionalArquivo>()), Times.Exactly(2));
+            transactionMock.Verify(t => t.Commit(), Times.Once);
+            _servicoMoverArquivoTemporarioMock.Verify(s => s.Mover(TipoArquivo.AcervoTridimensional, It.IsAny<Arquivo>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task DadoAcervoValidoSemArquivos_QuandoChamarInserir_EntaoExecutaFluxoSemProcessarArquivos()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO
+            {
+                Codigo = $"COD123{Constantes.SIGLA_ACERVO_TRIDIMENSIONAL}",
+                Arquivos = null
+            };
+            var acervoMapeado = new Acervo { Codigo = dto.Codigo };
+            var acervoTridimensionalMapeado = new AcervoTridimensional();
+            var acervoIdRetornado = 99L;
+            var transactionMock = new Mock<IDbTransaction>();
+
+            _mapperMock.Setup(m => m.Map<Acervo>(dto)).Returns(acervoMapeado);
+            _mapperMock.Setup(m => m.Map<AcervoTridimensional>(dto)).Returns(acervoTridimensionalMapeado);
+            _transacaoMock.Setup(t => t.Iniciar()).Returns(transactionMock.Object);
+            _servicoAcervoMock.Setup(s => s.Inserir(acervoMapeado)).ReturnsAsync(acervoIdRetornado);
+
+            // Act
+            var resultado = await _sut.Inserir(dto);
+
+            // Assert
+            resultado.Should().Be(acervoIdRetornado);
+            acervoMapeado.Codigo.Should().Be(dto.Codigo); // Não duplicou a sigla
+            _repositorioAcervoTridimensionalArquivoMock.Verify(r => r.Inserir(It.IsAny<AcervoTridimensionalArquivo>()), Times.Never);
+            transactionMock.Verify(t => t.Commit(), Times.Once);
+            _servicoMoverArquivoTemporarioMock.Verify(s => s.Mover(It.IsAny<TipoArquivo>(), It.IsAny<Arquivo>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DadoErroDePersistencia_QuandoChamarInserir_EntaoRealizaRollbackERethrowException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalCadastroDTO { Codigo = "COD" };
+            var transactionMock = new Mock<IDbTransaction>();
+
+            _mapperMock.Setup(m => m.Map<Acervo>(dto)).Returns(new Acervo { Codigo = "COD" });
+            _mapperMock.Setup(m => m.Map<AcervoTridimensional>(dto)).Returns(new AcervoTridimensional());
+            _transacaoMock.Setup(t => t.Iniciar()).Returns(transactionMock.Object);
+            _servicoAcervoMock.Setup(s => s.Inserir(It.IsAny<Acervo>())).ThrowsAsync(new System.Exception("Erro DB"));
+
+            // Act
+            var act = async () => await _sut.Inserir(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<System.Exception>().WithMessage("Erro DB");
+            transactionMock.Verify(t => t.Rollback(), Times.Once);
+            transactionMock.Verify(t => t.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoRegistrosExistentes_QuandoChamarObterTodos_EntaoRetornaColecaoMapeada()
+        {
+            // Arrange
+            var acervos = new List<AcervoTridimensional>
+            {
+                new() { Id = 1, Procedencia = "Proc A" },
+                new() { Id = 2, Procedencia = "Proc B" }
+            };
+            var acervoDTOs = new List<AcervoTridimensionalDTO>
+            {
+                new() { Id = 1, Procedencia = "Proc A" },
+                new() { Id = 2, Procedencia = "Proc B" }
+            };
+
+            _repositorioAcervoTridimensionalMock.Setup(r => r.ObterTodos()).ReturnsAsync(acervos);
+            _mapperMock.Setup(m => m.Map<AcervoTridimensionalDTO>(It.IsAny<AcervoTridimensional>()))
+                       .Returns((AcervoTridimensional a) => acervoDTOs.First(d => d.Id == a.Id));
+
+            // Act
+            var resultado = await _sut.ObterTodos();
+
+            // Assert
+            resultado.Should().NotBeNullOrEmpty();
+            resultado.Should().HaveCount(2);
+            resultado.Select(r => r.Procedencia).Should().Contain("Proc A", "Proc B");
+        }
+
+        [Fact]
+        public async Task DadoSemRegistros_QuandoChamarObterTodos_EntaoRetornaColecaoVazia()
+        {
+            // Arrange
+            _repositorioAcervoTridimensionalMock.Setup(r => r.ObterTodos()).ReturnsAsync(new List<AcervoTridimensional>());
+
+            // Act
+            var resultado = await _sut.ObterTodos();
+
+            // Assert
+            resultado.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task DadoCreditosAutoresPreenchidos_QuandoChamarAlterar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalAlteracaoDTO
+            {
+                CreditosAutoresIds = [1]
+            };
+
+            // Act
+            var act = async () => await _sut.Alterar(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(MensagemNegocio.ESSE_ACERVO_NAO_POSSUI_CREDITO_OU_AUTOR);
+        }
+
+        [Fact]
+        public async Task DadoDimensoesComFormatoInvalido_QuandoChamarAlterar_EntaoLancaNegocioException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalAlteracaoDTO
+            {
+                Largura = "inválido"
+            };
+
+            // Act
+            var act = async () => await _sut.Alterar(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<NegocioException>()
+                .WithMessage(string.Format(MensagemNegocio.CAMPO_X_ESPERADO_NUMERICO_E_COM_CASAS_DECIMAIS, Constantes.LARGURA));
+        }
+
+        [Fact]
+        public async Task DadoAcervoValido_QuandoChamarAlterar_EntaoExecutaFluxoCompletoERetornaDTO()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalAlteracaoDTO
+            {
+                Id = 10,
+                AcervoId = 99,
+                Codigo = "COD",
+                Arquivos = [1, 2]
+            };
+            var acervoTridimensional = new AcervoTridimensional { Id = 10 };
+            var acervoDto = new AcervoDto { Codigo = "COD" };
+            var transactionMock = new Mock<IDbTransaction>();
+            var arquivosAntigos = new List<AcervoTridimensionalArquivo> { new() { ArquivoId = 1 } };
+            var arquivosRetornadosBase = new List<Arquivo> { new() { Id = 2 } };
+            var acervoCompleto = new AcervoTridimensionalCompleto { Id = 10, Codigo = $"COD{Constantes.SIGLA_ACERVO_TRIDIMENSIONAL}" };
+            var dtoFinalEsperado = new AcervoTridimensionalDTO { Id = 10, Codigo = "COD" };
+
+            _repositorioArquivoMock.Setup(r => r.ObterPorIds(It.IsAny<long[]>())).ReturnsAsync(arquivosRetornadosBase);
+
+            _mapperMock.Setup(m => m.Map<AcervoTridimensional>(dto)).Returns(acervoTridimensional);
+            _mapperMock.Setup(m => m.Map<AcervoDto>(dto)).Returns(acervoDto);
+            _repositorioAcervoTridimensionalArquivoMock.Setup(r => r.ObterPorAcervoTridimensionalId(dto.Id)).ReturnsAsync(arquivosAntigos);
+            _transacaoMock.Setup(t => t.Iniciar()).Returns(transactionMock.Object);
+
+            _repositorioAcervoTridimensionalMock.Setup(r => r.ObterPorId(dto.AcervoId)).ReturnsAsync(acervoCompleto);
+            _mapperMock.Setup(m => m.Map<AcervoTridimensionalDTO>(acervoCompleto)).Returns(dtoFinalEsperado);
+            _mapperMock.Setup(m => m.Map<AuditoriaDTO>(acervoCompleto)).Returns(new AuditoriaDTO());
+
+            // Act
+            var resultado = await _sut.Alterar(dto);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Id.Should().Be(10);
+
+            _servicoAcervoMock.Verify(s => s.Alterar(acervoDto), Times.Once);
+            _repositorioAcervoTridimensionalMock.Verify(r => r.Atualizar(acervoTridimensional), Times.Once);
+            _repositorioAcervoTridimensionalArquivoMock.Verify(r => r.Inserir(It.Is<AcervoTridimensionalArquivo>(a => a.ArquivoId == 2)), Times.Once);
+            _repositorioAcervoTridimensionalArquivoMock.Verify(r => r.Excluir(It.Is<long[]>(l => l.Length == 0), acervoTridimensional.Id), Times.Once);
+            transactionMock.Verify(t => t.Commit(), Times.Once);
+            _servicoMoverArquivoTemporarioMock.Verify(s => s.Mover(TipoArquivo.AcervoTridimensional, It.IsAny<Arquivo>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoErroDePersistencia_QuandoChamarAlterar_EntaoRealizaRollbackERethrowException()
+        {
+            // Arrange
+            var dto = new AcervoTridimensionalAlteracaoDTO { Id = 10, AcervoId = 99, Codigo = "COD" };
+            var transactionMock = new Mock<IDbTransaction>();
+
+            _mapperMock.Setup(m => m.Map<AcervoTridimensional>(dto)).Returns(new AcervoTridimensional());
+            _mapperMock.Setup(m => m.Map<AcervoDto>(dto)).Returns(new AcervoDto() { Codigo = "COD" });
+
+            _repositorioAcervoTridimensionalArquivoMock.Setup(r => r.ObterPorAcervoTridimensionalId(dto.Id)).ReturnsAsync(new List<AcervoTridimensionalArquivo>());
+            _repositorioArquivoMock.Setup(r => r.ObterPorIds(It.IsAny<long[]>())).ReturnsAsync(new List<Arquivo>());
+
+            _transacaoMock.Setup(t => t.Iniciar()).Returns(transactionMock.Object);
+            _servicoAcervoMock.Setup(s => s.Alterar(It.IsAny<AcervoDto>())).ThrowsAsync(new System.Exception("Erro Atualizacao DB"));
+
+            // Act
+            var act = async () => await _sut.Alterar(dto);
+
+            // Assert
+            await act.Should().ThrowAsync<System.Exception>().WithMessage("Erro Atualizacao DB");
+            transactionMock.Verify(t => t.Rollback(), Times.Once);
+            transactionMock.Verify(t => t.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoInexistente_QuandoChamarObterPorId_EntaoRetornaNulo()
+        {
+            // Arrange
+            long id = 99;
+            _repositorioAcervoTridimensionalMock.Setup(r => r.ObterPorId(id)).ReturnsAsync((AcervoTridimensionalCompleto)null!);
+
+            // Act
+            var resultado = await _sut.ObterPorId(id);
+
+            // Assert
+            resultado.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task DadoAcervoExistente_QuandoChamarObterPorId_EntaoRetornaDTOMapeadoERemoveSufixo()
+        {
+            // Arrange
+            long id = 1;
+            var acervoBD = new AcervoTridimensionalCompleto { Id = 1, Codigo = $"COD{Constantes.SIGLA_ACERVO_TRIDIMENSIONAL}" };
+            var dtoMapeado = new AcervoTridimensionalDTO { Id = 1, Codigo = "COD" };
+            var auditoriaMapeada = new AuditoriaDTO();
+
+            _repositorioAcervoTridimensionalMock.Setup(r => r.ObterPorId(id)).ReturnsAsync(acervoBD);
+            _mapperMock.Setup(m => m.Map<AcervoTridimensionalDTO>(acervoBD)).Returns(dtoMapeado);
+            _mapperMock.Setup(m => m.Map<AuditoriaDTO>(acervoBD)).Returns(auditoriaMapeada);
+
+            // Act
+            var resultado = await _sut.ObterPorId(id);
+
+            // Assert
+            resultado.Should().NotBeNull();
+            resultado.Codigo.Should().Be("COD");
+            resultado.Auditoria.Should().BeSameAs(auditoriaMapeada);
+            _mapperMock.Verify(m => m.Map<AcervoTridimensionalDTO>(acervoBD), Times.Once);
+            _mapperMock.Verify(m => m.Map<AuditoriaDTO>(acervoBD), Times.Once);
+        }
+
+        [Fact]
+        public async Task DadoAcervoExistente_QuandoChamarExcluir_EntaoInvocaServicoBaseERetornaVerdadeiro()
+        {
+            // Arrange
+            long id = 10;
+            _servicoAcervoMock.Setup(s => s.Excluir(id)).ReturnsAsync(true);
+
+            // Act
+            var resultado = await _sut.Excluir(id);
+
+            // Assert
+            resultado.Should().BeTrue();
+            _servicoAcervoMock.Verify(s => s.Excluir(id), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
test: Refatora e amplia testes de acervo bibliográfico e 3D

Refatora completamente os testes de ServicoAcervoBibliografico, adicionando cenários abrangentes de validação, transação, mapeamento e regras de negócio.
Adiciona nova suíte de testes unitários para ServicoAcervoTridimensional, cobrindo inserção, alteração, validações, transações e integrações com arquivos.
Utiliza FluentAssertions e Moq para maior clareza e robustez, removendo testes antigos baseados em regiões e display names.
Melhora significativamente a cobertura e a manutenção dos testes das camadas de serviço de acervo.

[AB#146238](https://dev.azure.com/SME-Spassu/0b58ecd5-9e31-4506-a06c-32fdd13d5466/_workitems/edit/146238)